### PR TITLE
feat(experience): add CLI subcommands and comprehensive documentation

### DIFF
--- a/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/tools/experience/ExperienceModelsExtendedTest.kt
+++ b/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/tools/experience/ExperienceModelsExtendedTest.kt
@@ -1,0 +1,484 @@
+package ai.platon.pulsar.agentic.tools.experience
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlin.test.*
+
+/**
+ * Additional coverage for gaps identified in the PEM test coverage audit:
+ * - Missing Intent classifications (7 of 11)
+ * - Missing FailureCategory classifications (8 of 12)
+ * - Confidence edge cases (floor/cap, recency decay, withFailure)
+ * - SelectorStats.stabilityScore
+ * - TaskType and SuccessCriteria
+ */
+@DisplayName("Experience Models — Extended Coverage")
+class ExperienceModelsExtendedTest {
+
+    @Nested
+    @DisplayName("Intent classification — remaining intents")
+    inner class RemainingIntentClassification {
+        @Test
+        @DisplayName("classifies Book from keywords")
+        fun testClassifyBook() {
+            assertEquals(Intent.BOOK, Intent.classify("book a flight to Tokyo"))
+            assertEquals(Intent.BOOK, Intent.classify("reserve a hotel room"))
+            assertEquals(Intent.BOOK, Intent.classify("get tickets for the concert"))
+        }
+
+        @Test
+        @DisplayName("classifies Checkout from keywords")
+        fun testClassifyCheckout() {
+            assertEquals(Intent.CHECKOUT, Intent.classify("checkout my cart"))
+            assertEquals(Intent.CHECKOUT, Intent.classify("place order now"))
+            assertEquals(Intent.CHECKOUT, Intent.classify("confirm purchase"))
+        }
+
+        @Test
+        @DisplayName("classifies Extract from keywords")
+        fun testClassifyExtract() {
+            assertEquals(Intent.EXTRACT, Intent.classify("extract product details"))
+            assertEquals(Intent.EXTRACT, Intent.classify("scrape the page data"))
+            assertEquals(Intent.EXTRACT, Intent.classify("collect all prices"))
+            assertEquals(Intent.EXTRACT, Intent.classify("fetch the article text"))
+        }
+
+        @Test
+        @DisplayName("classifies Compare from keywords")
+        fun testClassifyCompare() {
+            assertEquals(Intent.COMPARE, Intent.classify("compare these two products"))
+            assertEquals(Intent.COMPARE, Intent.classify("laptop vs desktop"))
+            assertEquals(Intent.COMPARE, Intent.classify("difference between these options"))
+        }
+
+        @Test
+        @DisplayName("classifies Download from keywords")
+        fun testClassifyDownload() {
+            assertEquals(Intent.DOWNLOAD, Intent.classify("download the report"))
+            assertEquals(Intent.DOWNLOAD, Intent.classify("save file to disk"))
+            assertEquals(Intent.DOWNLOAD, Intent.classify("export data as CSV"))
+        }
+
+        @Test
+        @DisplayName("classifies FillForm from keywords")
+        fun testClassifyFillForm() {
+            assertEquals(Intent.FILL_FORM, Intent.classify("fill out the registration form"))
+            assertEquals(Intent.FILL_FORM, Intent.classify("sign up for newsletter"))
+            assertEquals(Intent.FILL_FORM, Intent.classify("subscribe to updates"))
+            assertEquals(Intent.FILL_FORM, Intent.classify("apply for the job"))
+        }
+
+        @Test
+        @DisplayName("classifies Monitor from keywords")
+        fun testClassifyMonitor() {
+            assertEquals(Intent.MONITOR, Intent.classify("monitor the price changes"))
+            assertEquals(Intent.MONITOR, Intent.classify("watch this page for updates"))
+            assertEquals(Intent.MONITOR, Intent.classify("track the stock level"))
+            assertEquals(Intent.MONITOR, Intent.classify("alert me when it changes"))
+            assertEquals(Intent.MONITOR, Intent.classify("notify if price drops"))
+        }
+
+        @Test
+        @DisplayName("classifies Other for unrecognized text")
+        fun testClassifyOther() {
+            assertEquals(Intent.OTHER, Intent.classify(""))
+            assertEquals(Intent.OTHER, Intent.classify(null))
+            assertEquals(Intent.OTHER, Intent.classify("do something vague"))
+            assertEquals(Intent.OTHER, Intent.classify("xyzzy plugh"))
+        }
+    }
+
+    @Nested
+    @DisplayName("FailureCategory classification — remaining categories")
+    inner class RemainingFailureClassification {
+        @Test
+        @DisplayName("classifies visual drift")
+        fun testVisualDrift() {
+            assertEquals(
+                FailureCategory.VISUAL_DRIFT,
+                FailureCategory.classify("element not visible on page")
+            )
+            assertEquals(
+                FailureCategory.VISUAL_DRIFT,
+                FailureCategory.classify("button is obscured by another element")
+            )
+            assertEquals(
+                FailureCategory.VISUAL_DRIFT,
+                FailureCategory.classify("element position changed after scroll")
+            )
+            assertTrue(FailureCategory.VISUAL_DRIFT.recoverable)
+        }
+
+        @Test
+        @DisplayName("classifies network errors")
+        fun testNetwork() {
+            assertEquals(
+                FailureCategory.NETWORK,
+                FailureCategory.classify("connection timeout after 30s")
+            )
+            assertEquals(
+                FailureCategory.NETWORK,
+                FailureCategory.classify("ECONNREFUSED: server not reachable")
+            )
+            assertTrue(FailureCategory.NETWORK.recoverable)
+        }
+
+        @Test
+        @DisplayName("classifies permission denied")
+        fun testPermissionDenied() {
+            assertEquals(
+                FailureCategory.PERMISSION_DENIED,
+                FailureCategory.classify("permission denied for this operation")
+            )
+            assertEquals(
+                FailureCategory.PERMISSION_DENIED,
+                FailureCategory.classify("admin only access required")
+            )
+            assertFalse(FailureCategory.PERMISSION_DENIED.recoverable)
+        }
+
+        @Test
+        @DisplayName("classifies timing issues")
+        fun testTiming() {
+            assertEquals(
+                FailureCategory.TIMING,
+                FailureCategory.classify("page still loading after timeout")
+            )
+            assertEquals(
+                FailureCategory.TIMING,
+                FailureCategory.classify("element not ready for interaction")
+            )
+            assertEquals(
+                FailureCategory.TIMING,
+                FailureCategory.classify("wait for selector timed out")
+            )
+            assertTrue(FailureCategory.TIMING.recoverable)
+        }
+
+        @Test
+        @DisplayName("classifies lazy loading failures")
+        fun testLazyLoading() {
+            assertEquals(
+                FailureCategory.LAZY_LOADING,
+                FailureCategory.classify("lazy-loaded image placeholder detected")
+            )
+            assertEquals(
+                FailureCategory.LAZY_LOADING,
+                FailureCategory.classify("data-src attribute not yet replaced")
+            )
+            assertTrue(FailureCategory.LAZY_LOADING.recoverable)
+        }
+
+        @Test
+        @DisplayName("classifies A/B experiment drift")
+        fun testAbExperiment() {
+            assertEquals(
+                FailureCategory.AB_EXPERIMENT,
+                FailureCategory.classify("selector not in current A/B variant")
+            )
+            assertEquals(
+                FailureCategory.AB_EXPERIMENT,
+                FailureCategory.classify("split test variant differs from baseline")
+            )
+            assertTrue(FailureCategory.AB_EXPERIMENT.recoverable)
+        }
+
+        @Test
+        @DisplayName("classifies unexpected redirect")
+        fun testUnexpectedRedirect() {
+            assertEquals(
+                FailureCategory.UNEXPECTED_REDIRECT,
+                FailureCategory.classify("redirected to unexpected URL during checkout")
+            )
+            assertEquals(
+                FailureCategory.UNEXPECTED_REDIRECT,
+                FailureCategory.classify("page moved to different domain")
+            )
+            assertTrue(FailureCategory.UNEXPECTED_REDIRECT.recoverable)
+        }
+
+        @Test
+        @DisplayName("UNKNOWN with non-null message")
+        fun testUnknownWithMessage() {
+            assertEquals(
+                FailureCategory.UNKNOWN,
+                FailureCategory.classify("some completely unclassified error")
+            )
+            assertFalse(FailureCategory.UNKNOWN.recoverable)
+        }
+
+        @Test
+        @DisplayName("ANTI_BOT is the only category that degrades retrieval")
+        fun testOnlyAntiBotDegradesRetrieval() {
+            val degradingCategories = FailureCategory.entries.filter { it.degradeRetrieval }
+            assertEquals(1, degradingCategories.size)
+            assertEquals(FailureCategory.ANTI_BOT, degradingCategories.first())
+        }
+    }
+
+    @Nested
+    @DisplayName("Confidence edge cases")
+    inner class ConfidenceEdgeCases {
+        @Test
+        @DisplayName("confidence is capped at 0.95")
+        fun testConfidenceCap() {
+            val stats = ExperienceStats(
+                intent = "buy", domain = "example.com", urlPattern = "/*",
+                totalAttempts = 1000, successes = 1000, failures = 0,
+                lastUpdated = Instant.now(),
+            )
+            assertTrue(stats.confidence <= ExperienceStats.CAP,
+                "Confidence ${stats.confidence} should not exceed cap ${ExperienceStats.CAP}")
+        }
+
+        @Test
+        @DisplayName("confidence floors at 0.05")
+        fun testConfidenceFloor() {
+            val stats = ExperienceStats(
+                intent = "buy", domain = "example.com", urlPattern = "/*",
+                totalAttempts = 1000, successes = 0, failures = 1000,
+                lastUpdated = Instant.now().minus(365, ChronoUnit.DAYS),
+            )
+            assertTrue(stats.confidence >= ExperienceStats.FLOOR,
+                "Confidence ${stats.confidence} should not go below floor ${ExperienceStats.FLOOR}")
+        }
+
+        @Test
+        @DisplayName("recency decay reduces confidence over time")
+        fun testRecencyDecay() {
+            val recent = ExperienceStats(
+                intent = "buy", domain = "example.com", urlPattern = "/*",
+                totalAttempts = 10, successes = 8, failures = 2,
+                lastUpdated = Instant.now(),
+            )
+            val stale = recent.copy(
+                lastUpdated = Instant.now().minus(180, ChronoUnit.DAYS),
+            )
+            assertTrue(stale.confidence < recent.confidence,
+                "Stale confidence ${stale.confidence} should be lower than recent ${recent.confidence}")
+        }
+
+        @Test
+        @DisplayName("withFailure produces correct failure stats")
+        fun testWithFailureUpdatesStats() {
+            val stats = ExperienceStats.create("buy", "amazon.com", "/dp/*")
+            val trace = TraceRecord(
+                intent = "buy", domain = "amazon.com",
+                url = "https://amazon.com/dp/test", urlPattern = "/dp/*",
+                outcome = "failure",
+                failureCategory = "anti_bot",
+                actions = listOf(
+                    ActionStep(1, "click", selector = "#btn", result = "error: captcha detected"),
+                ),
+            )
+            val updated = stats.withFailure(trace)
+            assertEquals(1, updated.failures)
+            assertEquals(1, updated.totalAttempts)
+            assertEquals(1, updated.failureStats["anti_bot"])
+            // Selector stats should record the failure
+            assertTrue(updated.selectorStats.containsKey("#btn"))
+            assertEquals(1, updated.selectorStats["#btn"]?.failures)
+        }
+
+        @Test
+        @DisplayName("selectorStats aggregation across multiple traces")
+        fun testSelectorStatsAggregation() {
+            val stats = ExperienceStats.create("buy", "amazon.com", "/dp/*")
+            val successTrace = TraceRecord(
+                intent = "buy", domain = "amazon.com",
+                url = "https://amazon.com/dp/1", urlPattern = "/dp/*",
+                outcome = "success",
+                actions = listOf(ActionStep(1, "click", selector = "#good-btn", result = "success")),
+            )
+            val failureTrace = TraceRecord(
+                intent = "buy", domain = "amazon.com",
+                url = "https://amazon.com/dp/2", urlPattern = "/dp/*",
+                outcome = "failure",
+                failureCategory = "selector_drift",
+                actions = listOf(ActionStep(1, "click", selector = "#bad-btn", result = "error: element not found")),
+            )
+            val afterSuccess = stats.withSuccess(successTrace)
+            val afterBoth = afterSuccess.withFailure(failureTrace)
+
+            assertEquals(1, afterBoth.selectorStats["#good-btn"]?.successes)
+            assertEquals(1, afterBoth.selectorStats["#bad-btn"]?.failures)
+            assertEquals(2, afterBoth.totalAttempts)
+            assertEquals(1, afterBoth.successes)
+            assertEquals(1, afterBoth.failures)
+        }
+
+        @Test
+        @DisplayName("retrieval tiers map correctly to confidence ranges")
+        fun testRetrievalTiers() {
+            // P1: >= 0.85
+            val p1Stats = ExperienceStats(
+                intent = "buy", domain = "a.com", urlPattern = "/*",
+                totalAttempts = 100, successes = 99, failures = 1,
+                lastUpdated = Instant.now(),
+            )
+            assertTrue(p1Stats.confidence >= 0.85, "Expected P1 confidence but got ${p1Stats.confidence}")
+            assertEquals("P1", p1Stats.retrievalTier)
+
+            // P2: >= 0.60
+            val p2Stats = ExperienceStats(
+                intent = "buy", domain = "b.com", urlPattern = "/*",
+                totalAttempts = 10, successes = 7, failures = 3,
+                lastUpdated = Instant.now(),
+            )
+            assertTrue(p2Stats.confidence in 0.60..0.84, "Expected P2 confidence but got ${p2Stats.confidence}")
+            assertEquals("P2", p2Stats.retrievalTier)
+
+            // P3: >= 0.40
+            val p3Stats = ExperienceStats(
+                intent = "buy", domain = "c.com", urlPattern = "/*",
+                totalAttempts = 5, successes = 2, failures = 3,
+                lastUpdated = Instant.now(),
+            )
+            assertTrue(p3Stats.confidence in 0.40..0.59, "Expected P3 confidence but got ${p3Stats.confidence}")
+            assertEquals("P3", p3Stats.retrievalTier)
+
+            // P4: < 0.40
+            val p4Stats = ExperienceStats(
+                intent = "buy", domain = "d.com", urlPattern = "/*",
+                totalAttempts = 10, successes = 1, failures = 9,
+                lastUpdated = Instant.now().minus(300, ChronoUnit.DAYS),
+            )
+            assertTrue(p4Stats.confidence < 0.40, "Expected P4 confidence but got ${p4Stats.confidence}")
+            assertEquals("P4", p4Stats.retrievalTier)
+        }
+
+        @Test
+        @DisplayName("ANtI_BOT in failure stats degrades retrieval tier")
+        fun testTierDegradationFromAntiBot() {
+            // High confidence but with anti-bot failures → should degrade from P1 to P2
+            val stats = ExperienceStats(
+                intent = "buy", domain = "blocked.com", urlPattern = "/*",
+                totalAttempts = 100, successes = 99, failures = 1,
+                failureStats = mapOf("anti_bot" to 1),
+                lastUpdated = Instant.now(),
+            )
+            assertTrue(stats.confidence >= 0.85, "Should be P1 by confidence alone")
+            assertEquals("P2", stats.retrievalTier, "Should degrade to P2 due to anti_bot")
+            assertTrue(stats.degradedByFailures)
+        }
+    }
+
+    @Nested
+    @DisplayName("SelectorStats stability score")
+    inner class SelectorStatsTests {
+        @Test
+        @DisplayName("fresh selector has stability 0.5")
+        fun testFreshSelector() {
+            val ss = SelectorStats(selector = "#btn")
+            assertEquals(0.5, ss.stabilityScore)
+        }
+
+        @Test
+        @DisplayName("stability increases with successes")
+        fun testStabilityIncreases() {
+            val ss = SelectorStats(selector = "#btn", successes = 10, failures = 0)
+            assertTrue(ss.stabilityScore > 0.9, "10/0 should have high stability")
+        }
+
+        @Test
+        @DisplayName("stability decreases with failures")
+        fun testStabilityDecreases() {
+            val good = SelectorStats(selector = "#good", successes = 9, failures = 1)
+            val bad = SelectorStats(selector = "#bad", successes = 1, failures = 9)
+            assertTrue(good.stabilityScore > bad.stabilityScore,
+                "Good selector stability ${good.stabilityScore} should exceed bad ${bad.stabilityScore}")
+        }
+    }
+
+    @Nested
+    @DisplayName("TaskType and SuccessCriteria")
+    inner class TaskTypeTests {
+        @Test
+        @DisplayName("fromString resolves case-insensitively")
+        fun testFromString() {
+            assertEquals(TaskType.SEARCH, TaskType.fromString("search"))
+            assertEquals(TaskType.SEARCH, TaskType.fromString("SEARCH"))
+            assertEquals(TaskType.EXTRACT_PRODUCT_DETAIL, TaskType.fromString("extract_product_detail"))
+        }
+
+        @Test
+        @DisplayName("fromStringOrNull returns null for unknown")
+        fun testFromStringOrNull() {
+            assertNull(TaskType.fromStringOrNull("nonexistent_type"))
+            assertNotNull(TaskType.fromStringOrNull("navigate"))
+        }
+
+        @Test
+        @DisplayName("fromString throws for unknown")
+        fun testFromStringThrows() {
+            assertFailsWith<IllegalArgumentException> {
+                TaskType.fromString("invalid_task_type")
+            }
+        }
+
+        @Test
+        @DisplayName("all task types have default success criteria")
+        fun testSuccessCriteriaDefaults() {
+            for (taskType in TaskType.entries) {
+                val criteria = SuccessCriteria.DEFAULTS[taskType]
+                // Each task type may or may not have criteria, but the map lookup should work
+                if (criteria != null) {
+                    assertTrue(criteria.isNotEmpty(), "$taskType has empty criteria list")
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("there are 12 task types")
+        fun testTaskTypeCount() {
+            assertEquals(12, TaskType.entries.size)
+        }
+    }
+
+    @Nested
+    @DisplayName("PatternPromotion canPromote logic")
+    inner class PatternPromotionTests {
+        @Test
+        @DisplayName("cannot promote with no sites")
+        fun testCannotPromoteNoSites() {
+            val pp = PatternPromotion(level = PromotionLevel.FAMILY)
+            assertFalse(pp.canPromote)
+        }
+
+        @Test
+        @DisplayName("cannot promote below min sites")
+        fun testCannotPromoteInsufficientSites() {
+            val pp = PatternPromotion(
+                level = PromotionLevel.CATEGORY, // min 3
+                confirmedSites = listOf("amazon.com", "ebay.com"),
+                disconfirmedSites = emptyList(),
+            )
+            assertFalse(pp.canPromote)
+        }
+
+        @Test
+        @DisplayName("can promote when ratio >= 75% and min sites met")
+        fun testCanPromoteSufficient() {
+            val pp = PatternPromotion(
+                level = PromotionLevel.FAMILY, // min 2
+                confirmedSites = listOf("amazon.com", "ebay.com", "walmart.com"),
+                disconfirmedSites = listOf("etsy.com"), // 3/4 = 75% → meets threshold
+            )
+            assertTrue(pp.canPromote)
+        }
+
+        @Test
+        @DisplayName("cannot promote when ratio below 75%")
+        fun testCannotPromoteLowRatio() {
+            val pp = PatternPromotion(
+                level = PromotionLevel.FAMILY, // min 2
+                confirmedSites = listOf("amazon.com", "ebay.com"),
+                disconfirmedSites = listOf("walmart.com", "etsy.com", "target.com"), // 2/5 = 40%
+            )
+            assertFalse(pp.canPromote)
+        }
+    }
+}

--- a/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/tools/experience/ExperienceToolExecutorExtendedTest.kt
+++ b/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/tools/experience/ExperienceToolExecutorExtendedTest.kt
@@ -1,0 +1,617 @@
+package ai.platon.pulsar.agentic.tools.experience
+
+import ai.platon.pulsar.common.serialize.json.pulsarObjectMapper
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.deleteRecursively
+import kotlin.test.*
+
+/**
+ * Additional coverage for ExperienceToolExecutor gaps:
+ * - experience_list with data after save+deep_learn
+ * - experience_save edge cases (missing args, invalid JSON)
+ * - experience_deep_learn promotion to CANDIDATE and VERIFIED
+ * - experience_query with no intent
+ * - experience_query after multiple saves on different domains
+ */
+@OptIn(ExperimentalPathApi::class)
+@DisplayName("ExperienceToolExecutor — Extended Coverage")
+class ExperienceToolExecutorExtendedTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var executor: ExperienceToolExecutor
+    private lateinit var knowledgeStore: KnowledgeStore
+    private val mapper = pulsarObjectMapper()
+
+    @BeforeEach
+    fun setUp() {
+        knowledgeStore = KnowledgeStore(tempDir)
+        knowledgeStore.initializeStore()
+        executor = ExperienceToolExecutor(knowledgeStore)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try { tempDir.deleteRecursively() } catch (_: Exception) {}
+    }
+
+    @Nested
+    @DisplayName("experience_save — edge cases")
+    inner class SaveEdgeCases {
+        @Test
+        @DisplayName("save with task_type parameter")
+        fun testSaveWithTaskType() = runBlocking {
+            val trace = ExecutionTrace(
+                url = "https://amazon.com/dp/test",
+                taskType = "extract_product_detail",
+                outcome = "success",
+            )
+            val result = executor.callFunctionOn(
+                domain = "experience", functionName = "save",
+                args = mapOf(
+                    "url" to "https://amazon.com/dp/test",
+                    "trace" to mapper.writeValueAsString(trace),
+                    "task_type" to "navigate",
+                ),
+                receiver = knowledgeStore,
+            )
+            val json = mapper.readTree(result as String)
+            assertEquals(true, json["saved"].asBoolean())
+            // task_type should be stored
+        }
+
+        @Test
+        @DisplayName("save defaults outcome to success when omitted")
+        fun testSaveDefaultOutcome() = runBlocking {
+            val trace = ExecutionTrace(
+                url = "https://example.com/page",
+                taskType = "navigate",
+                outcome = "success",
+            )
+            val result = executor.callFunctionOn(
+                domain = "experience", functionName = "save",
+                args = mapOf(
+                    "url" to "https://example.com/page",
+                    "trace" to mapper.writeValueAsString(trace),
+                ),
+                receiver = knowledgeStore,
+            )
+            val json = mapper.readTree(result as String)
+            assertEquals(true, json["saved"].asBoolean())
+            assertEquals("success", json["outcome"].asText())
+        }
+
+        @Test
+        @DisplayName("save with empty steps list is valid")
+        fun testSaveWithEmptySteps() = runBlocking {
+            val trace = ExecutionTrace(
+                url = "https://example.com",
+                taskType = "navigate",
+                outcome = "success",
+                steps = emptyList(),
+            )
+            val result = executor.callFunctionOn(
+                domain = "experience", functionName = "save",
+                args = mapOf(
+                    "url" to "https://example.com",
+                    "trace" to mapper.writeValueAsString(trace),
+                ),
+                receiver = knowledgeStore,
+            )
+            val json = mapper.readTree(result as String)
+            assertEquals(true, json["saved"].asBoolean())
+        }
+
+        @Test
+        @DisplayName("save with null intent classifies as OTHER")
+        fun testSaveWithNullIntent() = runBlocking {
+            val trace = ExecutionTrace(
+                url = "https://example.com/page",
+                taskType = "navigate",
+                outcome = "success",
+            )
+            val result = executor.callFunctionOn(
+                domain = "experience", functionName = "save",
+                args = mapOf(
+                    "url" to "https://example.com/page",
+                    "trace" to mapper.writeValueAsString(trace),
+                    // intent intentionally omitted
+                ),
+                receiver = knowledgeStore,
+            )
+            val json = mapper.readTree(result as String)
+            assertEquals(true, json["saved"].asBoolean())
+            // Intent should be classified as "other" (null → OTHER)
+            assertNotNull(json["intent"]?.asText())
+        }
+
+        @Test
+        @DisplayName("save throws on missing url")
+        fun testSaveMissingUrl() = runBlocking {
+            assertFailsWith<Exception> {
+                executor.callFunctionOn(
+                    domain = "experience", functionName = "save",
+                    args = mapOf(
+                        "trace" to "{}",
+                    ),
+                    receiver = knowledgeStore,
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("save throws on invalid trace JSON")
+        fun testSaveInvalidTraceJson() = runBlocking {
+            assertFailsWith<IllegalArgumentException> {
+                executor.callFunctionOn(
+                    domain = "experience", functionName = "save",
+                    args = mapOf(
+                        "url" to "https://example.com",
+                        "trace" to "not valid json {{{",
+                    ),
+                    receiver = knowledgeStore,
+                )
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("experience_query — edge cases")
+    inner class QueryEdgeCases {
+        @Test
+        @DisplayName("query with no intent still works")
+        fun testQueryNoIntent() = runBlocking {
+            val result = executor.callFunctionOn(
+                domain = "experience", functionName = "query",
+                args = mapOf("url" to "https://amazon.com/dp/test"),
+                receiver = knowledgeStore,
+            )
+            val json = mapper.readTree(result as String)
+            assertEquals("P5", json["tier"].asText())
+            // Without intent it should still return a result (cold start)
+            assertNotNull(json["domain"]?.asText())
+        }
+
+        @Test
+        @DisplayName("query for unknown domain after saving other domains")
+        fun testQueryUnknownAfterSavingOthers() = runBlocking {
+            // Save knowledge for amazon
+            val trace = ExecutionTrace(
+                url = "https://amazon.com/dp/test",
+                taskType = "extract_product_detail",
+                outcome = "success",
+            )
+            executor.callFunctionOn(
+                domain = "experience", functionName = "save",
+                args = mapOf(
+                    "url" to "https://amazon.com/dp/test",
+                    "trace" to mapper.writeValueAsString(trace),
+                    "intent" to "buy product",
+                ),
+                receiver = knowledgeStore,
+            )
+            executor.callFunctionOn(
+                domain = "experience", functionName = "deep_learn",
+                args = mapOf(
+                    "url" to "https://amazon.com/dp/test",
+                    "intent" to "buy product",
+                ),
+                receiver = knowledgeStore,
+            )
+
+            // Query for a completely different domain
+            val result = executor.callFunctionOn(
+                domain = "experience", functionName = "query",
+                args = mapOf("url" to "https://ebay.com/itm/test", "intent" to "buy product"),
+                receiver = knowledgeStore,
+            )
+            val json = mapper.readTree(result as String)
+            // Should return P5 (cold start) for ebay since we only saved amazon
+            assertEquals("P5", json["tier"].asText())
+        }
+
+        @Test
+        @DisplayName("query then save then query shows knowledge progression")
+        fun testQuerySaveQueryProgression() = runBlocking {
+            // Initial query: cold start
+            val q1 = executor.callFunctionOn(
+                domain = "experience", functionName = "query",
+                args = mapOf("url" to "https://amazon.com/dp/test", "intent" to "buy product"),
+                receiver = knowledgeStore,
+            )
+            assertEquals("P5", mapper.readTree(q1 as String)["tier"].asText())
+
+            // Save trace
+            val trace = ExecutionTrace(
+                url = "https://amazon.com/dp/test",
+                taskType = "extract_product_detail",
+                outcome = "success",
+            )
+            executor.callFunctionOn(
+                domain = "experience", functionName = "save",
+                args = mapOf(
+                    "url" to "https://amazon.com/dp/test",
+                    "trace" to mapper.writeValueAsString(trace),
+                    "intent" to "buy product",
+                ),
+                receiver = knowledgeStore,
+            )
+
+            // Deep learn
+            executor.callFunctionOn(
+                domain = "experience", functionName = "deep_learn",
+                args = mapOf(
+                    "url" to "https://amazon.com/dp/test",
+                    "intent" to "buy product",
+                ),
+                receiver = knowledgeStore,
+            )
+
+            // Query again: should find knowledge
+            val q2 = executor.callFunctionOn(
+                domain = "experience", functionName = "query",
+                args = mapOf("url" to "https://amazon.com/dp/test", "intent" to "buy product"),
+                receiver = knowledgeStore,
+            )
+            assertNotEquals("P5", mapper.readTree(q2 as String)["tier"].asText(),
+                "Should not be cold start after save+deep_learn")
+        }
+    }
+
+    @Nested
+    @DisplayName("experience_deep_learn — promotion paths")
+    inner class DeepLearnPromotion {
+        @Test
+        @DisplayName("promotes to CANDIDATE after 2+ successes")
+        fun testPromoteToCandidate() = runBlocking {
+            // Save 3 successful traces
+            repeat(3) { i ->
+                val trace = ExecutionTrace(
+                    url = "https://amazon.com/dp/test$i",
+                    taskType = "extract_product_detail",
+                    outcome = "success",
+                )
+                executor.callFunctionOn(
+                    domain = "experience", functionName = "save",
+                    args = mapOf(
+                        "url" to "https://amazon.com/dp/test$i",
+                        "trace" to mapper.writeValueAsString(trace),
+                        "intent" to "extract product",
+                    ),
+                    receiver = knowledgeStore,
+                )
+            }
+
+            // Deep learn should promote to CANDIDATE (3 successes, confidence >= 0.60)
+            val result = executor.callFunctionOn(
+                domain = "experience", functionName = "deep_learn",
+                args = mapOf(
+                    "url" to "https://amazon.com/dp/test",
+                    "intent" to "extract product",
+                    "force" to "true",
+                ),
+                receiver = knowledgeStore,
+            )
+            val json = mapper.readTree(result as String)
+            val status = json["status_after"].asText().lowercase()
+            assertTrue(status in listOf("candidate", "verified"),
+                "Expected candidate or verified after 3 successes, got $status")
+        }
+
+        @Test
+        @DisplayName("promotes to VERIFIED after 5+ successes")
+        fun testPromoteToVerified() = runBlocking {
+            // Save 6 successful traces
+            repeat(6) { i ->
+                val trace = ExecutionTrace(
+                    url = "https://amazon.com/dp/test$i",
+                    taskType = "extract_product_detail",
+                    outcome = "success",
+                )
+                executor.callFunctionOn(
+                    domain = "experience", functionName = "save",
+                    args = mapOf(
+                        "url" to "https://amazon.com/dp/test$i",
+                        "trace" to mapper.writeValueAsString(trace),
+                        "intent" to "extract product",
+                    ),
+                    receiver = knowledgeStore,
+                )
+            }
+
+            val result = executor.callFunctionOn(
+                domain = "experience", functionName = "deep_learn",
+                args = mapOf(
+                    "url" to "https://amazon.com/dp/test",
+                    "intent" to "extract product",
+                    "force" to "true",
+                ),
+                receiver = knowledgeStore,
+            )
+            val json = mapper.readTree(result as String)
+            assertEquals("verified", json["status_after"].asText().lowercase())
+            assertEquals(true, json["promoted"].asBoolean())
+        }
+
+        @Test
+        @DisplayName("deep_learn with force=false on low confidence runs anyway")
+        fun testDeepLearnForceFalseLowConfidence() = runBlocking {
+            // Save just 1 trace (low confidence)
+            val trace = ExecutionTrace(
+                url = "https://amazon.com/dp/single",
+                taskType = "extract_product_detail",
+                outcome = "success",
+            )
+            executor.callFunctionOn(
+                domain = "experience", functionName = "save",
+                args = mapOf(
+                    "url" to "https://amazon.com/dp/single",
+                    "trace" to mapper.writeValueAsString(trace),
+                    "intent" to "extract product",
+                ),
+                receiver = knowledgeStore,
+            )
+
+            // force=false (or not specified), confidence should be < 0.90 → runs normally
+            val result = executor.callFunctionOn(
+                domain = "experience", functionName = "deep_learn",
+                args = mapOf(
+                    "url" to "https://amazon.com/dp/single",
+                    "intent" to "extract product",
+                    // force not set → defaults to false
+                ),
+                receiver = knowledgeStore,
+            )
+            val json = mapper.readTree(result as String)
+            // Should complete (confidence < 0.90 so it runs)
+            assertEquals(true, json["completed"].asBoolean())
+            assertEquals("hypothesis", json["status_after"].asText().lowercase())
+        }
+
+        @Test
+        @DisplayName("deep_learn after all failures still creates hypothesis")
+        fun testDeepLearnAfterAllFailures() = runBlocking {
+            // Save 3 failed traces only
+            repeat(3) { i ->
+                val trace = ExecutionTrace(
+                    url = "https://blocked.com/page$i",
+                    taskType = "search",
+                    outcome = "failure",
+                    errorMessage = "CAPTCHA detected on page",
+                )
+                executor.callFunctionOn(
+                    domain = "experience", functionName = "save",
+                    args = mapOf(
+                        "url" to "https://blocked.com/page$i",
+                        "trace" to mapper.writeValueAsString(trace),
+                        "outcome" to "failure",
+                        "intent" to "search product",
+                    ),
+                    receiver = knowledgeStore,
+                )
+            }
+
+            val result = executor.callFunctionOn(
+                domain = "experience", functionName = "deep_learn",
+                args = mapOf(
+                    "url" to "https://blocked.com/page",
+                    "intent" to "search product",
+                    "force" to "true",
+                ),
+                receiver = knowledgeStore,
+            )
+            val json = mapper.readTree(result as String)
+            // Should still create hypothesis even after only failures
+            assertEquals(true, json["completed"].asBoolean())
+            assertNotNull(json["status_after"]?.asText())
+        }
+    }
+
+    @Nested
+    @DisplayName("experience_list — with data")
+    inner class ListWithData {
+        @Test
+        @DisplayName("list returns entries after save+deep_learn")
+        fun testListAfterSaveAndDeepLearn() = runBlocking {
+            // Save and deep_learn for amazon
+            val trace = ExecutionTrace(
+                url = "https://amazon.com/dp/test",
+                taskType = "extract_product_detail",
+                outcome = "success",
+            )
+            executor.callFunctionOn(
+                domain = "experience", functionName = "save",
+                args = mapOf(
+                    "url" to "https://amazon.com/dp/test",
+                    "trace" to mapper.writeValueAsString(trace),
+                    "intent" to "buy product",
+                ),
+                receiver = knowledgeStore,
+            )
+            executor.callFunctionOn(
+                domain = "experience", functionName = "deep_learn",
+                args = mapOf(
+                    "url" to "https://amazon.com/dp/test",
+                    "intent" to "buy product",
+                    "force" to "true",
+                ),
+                receiver = knowledgeStore,
+            )
+
+            val result = executor.callFunctionOn(
+                domain = "experience", functionName = "list",
+                args = emptyMap(), receiver = knowledgeStore,
+            )
+            val json = mapper.readTree(result as String)
+            assertTrue(json["total"].asInt() >= 1, "Expected at least 1 entry after save+deep_learn")
+            assertEquals(1, json["page"].asInt())
+
+            val entry = json["entries"].get(0)
+            assertEquals("amazon.com", entry["domain"].asText())
+            assertEquals("buy", entry["intent"].asText())
+        }
+
+        @Test
+        @DisplayName("list with filter parameter")
+        fun testListWithFilter() = runBlocking {
+            // Save for two different domains
+            for ((domain, intent) in listOf("amazon.com" to "buy", "ebay.com" to "extract")) {
+                val trace = ExecutionTrace(
+                    url = "https://$domain/test",
+                    taskType = "extract_product_detail",
+                    outcome = "success",
+                )
+                executor.callFunctionOn(
+                    domain = "experience", functionName = "save",
+                    args = mapOf(
+                        "url" to "https://$domain/test",
+                        "trace" to mapper.writeValueAsString(trace),
+                        "intent" to intent,
+                    ),
+                    receiver = knowledgeStore,
+                )
+                executor.callFunctionOn(
+                    domain = "experience", functionName = "deep_learn",
+                    args = mapOf(
+                        "url" to "https://$domain/test",
+                        "intent" to intent,
+                        "force" to "true",
+                    ),
+                    receiver = knowledgeStore,
+                )
+            }
+
+            // Filter by domain
+            val filtered = executor.callFunctionOn(
+                domain = "experience", functionName = "list",
+                args = mapOf("filter" to "amazon"), receiver = knowledgeStore,
+            )
+            val json = mapper.readTree(filtered as String)
+            assertEquals(1, json["total"].asInt())
+            assertEquals("amazon.com", json["entries"].get(0)["domain"].asText())
+        }
+
+        @Test
+        @DisplayName("list with intent_filter parameter")
+        fun testListWithIntentFilter() = runBlocking {
+            // Save for two different intents
+            for ((domain, intent) in listOf("amazon.com" to "buy", "amazon.com" to "search")) {
+                val trace = ExecutionTrace(
+                    url = "https://$domain/test",
+                    outcome = "success",
+                )
+                executor.callFunctionOn(
+                    domain = "experience", functionName = "save",
+                    args = mapOf(
+                        "url" to "https://$domain/test",
+                        "trace" to mapper.writeValueAsString(trace),
+                        "intent" to intent,
+                    ),
+                    receiver = knowledgeStore,
+                )
+                executor.callFunctionOn(
+                    domain = "experience", functionName = "deep_learn",
+                    args = mapOf(
+                        "url" to "https://$domain/test",
+                        "intent" to intent,
+                        "force" to "true",
+                    ),
+                    receiver = knowledgeStore,
+                )
+            }
+
+            val buyResult = executor.callFunctionOn(
+                domain = "experience", functionName = "list",
+                args = mapOf("intent_filter" to "buy"), receiver = knowledgeStore,
+            )
+            assertEquals(1, mapper.readTree(buyResult as String)["total"].asInt())
+
+            val searchResult = executor.callFunctionOn(
+                domain = "experience", functionName = "list",
+                args = mapOf("intent_filter" to "search"), receiver = knowledgeStore,
+            )
+            assertEquals(1, mapper.readTree(searchResult as String)["total"].asInt())
+        }
+
+        @Test
+        @DisplayName("list pagination after multiple saves")
+        fun testListPagination() = runBlocking {
+            // Save 5 entries for different domains
+            for (i in 1..5) {
+                val trace = ExecutionTrace(
+                    url = "https://site$i.com/test",
+                    outcome = "success",
+                )
+                executor.callFunctionOn(
+                    domain = "experience", functionName = "save",
+                    args = mapOf(
+                        "url" to "https://site$i.com/test",
+                        "trace" to mapper.writeValueAsString(trace),
+                        "intent" to "buy",
+                    ),
+                    receiver = knowledgeStore,
+                )
+                executor.callFunctionOn(
+                    domain = "experience", functionName = "deep_learn",
+                    args = mapOf(
+                        "url" to "https://site$i.com/test",
+                        "intent" to "buy",
+                        "force" to "true",
+                    ),
+                    receiver = knowledgeStore,
+                )
+            }
+
+            val page1 = executor.callFunctionOn(
+                domain = "experience", functionName = "list",
+                args = mapOf("page" to "1", "page_size" to "3"), receiver = knowledgeStore,
+            )
+            val json1 = mapper.readTree(page1 as String)
+            assertEquals(5, json1["total"].asInt())
+            assertEquals(3, json1["entries"].size())
+            assertEquals(2, json1["total_pages"].asInt())
+
+            val page2 = executor.callFunctionOn(
+                domain = "experience", functionName = "list",
+                args = mapOf("page" to "2", "page_size" to "3"), receiver = knowledgeStore,
+            )
+            val json2 = mapper.readTree(page2 as String)
+            assertEquals(2, json2["entries"].size())
+        }
+    }
+
+    @Nested
+    @DisplayName("Unsupported method")
+    inner class UnsupportedMethod {
+        @Test
+        @DisplayName("throws on unknown function name")
+        fun testUnknownFunction() = runBlocking {
+            assertFailsWith<IllegalArgumentException> {
+                executor.callFunctionOn(
+                    domain = "experience", functionName = "nonexistent_method",
+                    args = emptyMap(), receiver = knowledgeStore,
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("throws on wrong domain")
+        fun testWrongDomain() = runBlocking {
+            assertFailsWith<IllegalArgumentException> {
+                executor.callFunctionOn(
+                    domain = "wrong_domain", functionName = "save",
+                    args = emptyMap(), receiver = knowledgeStore,
+                )
+            }
+        }
+    }
+}

--- a/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/tools/experience/KnowledgeStoreConcurrencyTest.kt
+++ b/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/tools/experience/KnowledgeStoreConcurrencyTest.kt
@@ -1,0 +1,324 @@
+package ai.platon.pulsar.agentic.tools.experience
+
+import kotlinx.coroutines.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.deleteRecursively
+import kotlin.test.*
+
+/**
+ * Tests for concurrent access to KnowledgeStore.
+ *
+ * Verifies that per-domain [Mutex] serialization in [KnowledgeStore.saveFacts]
+ * prevents data corruption when multiple coroutines write to the same domain
+ * simultaneously, while writes to different domains proceed concurrently.
+ */
+@OptIn(ExperimentalPathApi::class)
+@DisplayName("KnowledgeStore — Concurrent Access")
+class KnowledgeStoreConcurrencyTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var store: KnowledgeStore
+
+    @BeforeEach
+    fun setUp() {
+        store = KnowledgeStore(tempDir)
+        store.initializeStore()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try { tempDir.deleteRecursively() } catch (_: Exception) {}
+    }
+
+    @Nested
+    @DisplayName("concurrent writes to same domain serialize")
+    inner class SameDomainConcurrency {
+        @Test
+        @DisplayName("multiple coroutines writing to same domain do not corrupt data")
+        fun testConcurrentSameDomain() = runBlocking {
+            val iterations = 20
+            val completed = AtomicInteger(0)
+            val errors = mutableListOf<String>()
+
+            val jobs = List(iterations) { i ->
+                launch(Dispatchers.Default) {
+                    try {
+                        val facts = KnowledgeFacts(
+                            intent = "buy",
+                            domain = "amazon.com",
+                            urlPattern = "/dp/*",
+                            status = VerificationStatus.HYPOTHESIS,
+                            siteFacts = SiteFacts(domain = "amazon.com"),
+                        )
+                        store.saveFacts(facts)
+                        completed.incrementAndGet()
+                    } catch (e: Exception) {
+                        synchronized(errors) {
+                            errors.add("Coroutine $i failed: ${e.message}")
+                        }
+                    }
+                }
+            }
+
+            jobs.joinAll()
+            assertEquals(0, errors.size, "Expected no errors but got: $errors")
+            assertEquals(iterations, completed.get())
+
+            // Verify final state is intact
+            val loaded = store.loadFacts("amazon.com", "buy")
+            assertNotNull(loaded, "Facts should exist after concurrent writes")
+            assertEquals("amazon.com", loaded!!.domain)
+        }
+
+        @Test
+        @DisplayName("concurrent trace saves to same domain do not lose records")
+        fun testConcurrentTraceSaves() = runBlocking {
+            val count = 10
+            val jobs = List(count) { i ->
+                launch(Dispatchers.Default) {
+                    store.saveTrace(
+                        TraceRecord(
+                            intent = "search",
+                            domain = "amazon.com",
+                            url = "https://amazon.com/s?k=test$i",
+                            urlPattern = "/s?k=*",
+                            outcome = "success",
+                        )
+                    )
+                    store.updateStats(
+                        TraceRecord(
+                            intent = "search",
+                            domain = "amazon.com",
+                            url = "https://amazon.com/s?k=test$i",
+                            urlPattern = "/s?k=*",
+                            outcome = "success",
+                        )
+                    )
+                }
+            }
+            jobs.joinAll()
+
+            val traces = store.listTraces(domain = "amazon.com", pageSize = 100)
+            assertEquals(count, traces.size, "All $count traces should be saved")
+
+            val stats = store.loadStats("amazon.com", "search")
+            assertEquals(count, stats.successes)
+        }
+    }
+
+    @Nested
+    @DisplayName("concurrent writes to different domains run concurrently")
+    inner class DifferentDomainConcurrency {
+        @Test
+        @DisplayName("writes to different domains do not block each other")
+        fun testConcurrentDifferentDomains() = runBlocking {
+            val domains = listOf("amazon.com", "ebay.com", "walmart.com", "etsy.com", "target.com")
+            val completed = AtomicInteger(0)
+
+            val jobs = domains.map { domain ->
+                launch(Dispatchers.Default) {
+                    repeat(5) { i ->
+                        val facts = KnowledgeFacts(
+                            intent = "buy",
+                            domain = domain,
+                            urlPattern = "/product/*",
+                            status = VerificationStatus.HYPOTHESIS,
+                            siteFacts = SiteFacts(domain = domain),
+                        )
+                        store.saveFacts(facts)
+                    }
+                    completed.incrementAndGet()
+                }
+            }
+
+            jobs.joinAll()
+            assertEquals(domains.size, completed.get())
+
+            // Verify each domain's data is intact
+            for (domain in domains) {
+                val loaded = store.loadFacts(domain, "buy")
+                assertNotNull(loaded, "Facts should exist for $domain")
+                assertEquals(domain, loaded!!.domain)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("mixed read/write concurrency")
+    inner class MixedReadWriteConcurrency {
+        @Test
+        @DisplayName("reads during writes return consistent state")
+        fun testReadDuringWrites() = runBlocking {
+            // Pre-populate facts
+            store.saveFacts(
+                KnowledgeFacts(
+                    intent = "buy", domain = "amazon.com", urlPattern = "/dp/*",
+                    status = VerificationStatus.CANDIDATE,
+                    siteFacts = SiteFacts(domain = "amazon.com"),
+                )
+            )
+
+            val writerErrors = mutableListOf<String>()
+            val readerResults = mutableListOf<KnowledgeFacts?>()
+
+            val writer = launch(Dispatchers.Default) {
+                repeat(10) {
+                    try {
+                        val facts = KnowledgeFacts(
+                            intent = "buy", domain = "amazon.com", urlPattern = "/dp/*",
+                            status = VerificationStatus.CANDIDATE,
+                            siteFacts = SiteFacts(domain = "amazon.com", siteFamily = "amazon-like"),
+                        )
+                        store.saveFacts(facts)
+                    } catch (e: Exception) {
+                        synchronized(writerErrors) {
+                            writerErrors.add("Writer failed: ${e.message}")
+                        }
+                    }
+                }
+            }
+
+            val reader = launch(Dispatchers.Default) {
+                repeat(20) {
+                    val facts = store.loadFacts("amazon.com", "buy")
+                    synchronized(readerResults) {
+                        readerResults.add(facts)
+                    }
+                    delay(1) // Small delay to interleave
+                }
+            }
+
+            writer.join()
+            reader.join()
+
+            assertEquals(0, writerErrors.size, "Writers should not error: $writerErrors")
+            // All reads should return either the initial or updated facts — never null or corrupt
+            for (result in readerResults) {
+                assertNotNull(result, "Reader should always get valid facts")
+                assertEquals("amazon.com", result!!.domain)
+                assertEquals("buy", result.intent)
+            }
+        }
+
+        @Test
+        @DisplayName("query during concurrent updates returns consistent results")
+        fun testQueryDuringUpdates() = runBlocking {
+            // Pre-populate
+            store.saveFacts(
+                KnowledgeFacts(
+                    intent = "buy", domain = "amazon.com", urlPattern = "/dp/*",
+                    status = VerificationStatus.VERIFIED,
+                    siteFacts = SiteFacts(domain = "amazon.com"),
+                    selectors = mapOf("title" to VerifiedSelector(primary = "h1")),
+                )
+            )
+            // Add stats for non-P5 tier
+            repeat(5) {
+                store.updateStats(
+                    TraceRecord(
+                        intent = "buy", domain = "amazon.com",
+                        url = "https://amazon.com/dp/test$it", urlPattern = "/dp/*",
+                        outcome = "success", actions = emptyList(),
+                    )
+                )
+            }
+
+            val updateDone = AtomicInteger(0)
+            val queryResults = mutableListOf<String>()
+
+            val updater = launch(Dispatchers.Default) {
+                repeat(10) {
+                    store.updateStats(
+                        TraceRecord(
+                            intent = "buy", domain = "amazon.com",
+                            url = "https://amazon.com/dp/new$it", urlPattern = "/dp/*",
+                            outcome = "success", actions = emptyList(),
+                        )
+                    )
+                    updateDone.incrementAndGet()
+                }
+            }
+
+            val querier = launch(Dispatchers.Default) {
+                repeat(15) {
+                    val result = store.query("https://amazon.com/dp/test", "buy product")
+                    synchronized(queryResults) { queryResults.add(result.tier) }
+                    delay(1)
+                }
+            }
+
+            updater.join()
+            querier.join()
+
+            assertEquals(10, updateDone.get())
+            assertTrue(queryResults.isNotEmpty())
+            // All queries should return a valid tier (never P5 since we have data)
+            for (tier in queryResults) {
+                assertTrue(tier in listOf("P1", "P2", "P3", "P4"), "Unexpected tier: $tier")
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("stress: many coroutines, many domains")
+    inner class StressConcurrency {
+        @Test
+        @DisplayName("100 concurrent saves across 10 domains complete without errors")
+        fun testStressConcurrent() = runBlocking {
+            val domainCount = 10
+            val savesPerDomain = 10
+            val errors = mutableListOf<String>()
+
+            val jobs = (0 until domainCount).flatMap { d ->
+                (0 until savesPerDomain).map { i ->
+                    launch(Dispatchers.Default) {
+                        try {
+                            val domain = "site${d}.com"
+                            val facts = KnowledgeFacts(
+                                intent = "extract",
+                                domain = domain,
+                                urlPattern = "/data/*",
+                                status = VerificationStatus.HYPOTHESIS,
+                            )
+                            store.saveFacts(facts)
+                            store.updateStats(
+                                TraceRecord(
+                                    intent = "extract", domain = domain,
+                                    url = "https://$domain/data/$i", urlPattern = "/data/*",
+                                    outcome = "success",
+                                )
+                            )
+                        } catch (e: Exception) {
+                            synchronized(errors) {
+                                errors.add("d${d}-i$i failed: ${e.message}")
+                            }
+                        }
+                    }
+                }
+            }
+
+            jobs.joinAll()
+            assertEquals(0, errors.size, "Expected 0 errors but got: $errors")
+
+            // Verify all domains persisted correctly
+            for (d in 0 until domainCount) {
+                val domain = "site${d}.com"
+                val facts = store.loadFacts(domain, "extract")
+                assertNotNull(facts, "Facts missing for $domain")
+                val stats = store.loadStats(domain, "extract")
+                assertEquals(savesPerDomain, stats.totalAttempts,
+                    "Expected $savesPerDomain attempts for $domain")
+            }
+        }
+    }
+}

--- a/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/tools/experience/KnowledgeStoreExtendedTest.kt
+++ b/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/tools/experience/KnowledgeStoreExtendedTest.kt
@@ -1,0 +1,479 @@
+package ai.platon.pulsar.agentic.tools.experience
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import kotlin.io.path.*
+import kotlin.test.*
+
+/**
+ * Additional coverage for KnowledgeStore gaps:
+ * - list() with data, filters, and pagination
+ * - query() URL pattern match (L2 fallback)
+ * - promoteToVerified() boundary transitions
+ * - saveTrace auto-creates domain directory
+ * - loadTrace with invalid file
+ * - PromotionEvent history building
+ * - Concurrent stats updates across multiple domains
+ */
+@OptIn(ExperimentalPathApi::class)
+@DisplayName("KnowledgeStore — Extended Coverage")
+class KnowledgeStoreExtendedTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var store: KnowledgeStore
+
+    @BeforeEach
+    fun setUp() {
+        store = KnowledgeStore(tempDir)
+        store.initializeStore()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try { tempDir.toFile().deleteRecursively() } catch (_: Exception) {}
+    }
+
+    @Nested
+    @DisplayName("list() with data, filters, and pagination")
+    inner class ListWithData {
+        @Test
+        @DisplayName("list returns entries after saving facts")
+        fun testListWithEntries() = runBlocking {
+            // Save facts for two domains
+            store.saveFacts(KnowledgeFacts(
+                intent = "buy", domain = "amazon.com", urlPattern = "/dp/*",
+                status = VerificationStatus.VERIFIED,
+                siteFacts = SiteFacts(domain = "amazon.com", siteFamily = "amazon-like"),
+            ))
+            store.saveFacts(KnowledgeFacts(
+                intent = "extract", domain = "ebay.com", urlPattern = "/itm/*",
+                status = VerificationStatus.CANDIDATE,
+                siteFacts = SiteFacts(domain = "ebay.com", siteFamily = "ebay-like"),
+            ))
+            // Add stats for confidence
+            repeat(5) {
+                store.updateStats(TraceRecord(
+                    intent = "buy", domain = "amazon.com",
+                    url = "https://amazon.com/dp/test", urlPattern = "/dp/*",
+                    outcome = "success", actions = emptyList(),
+                ))
+                store.updateStats(TraceRecord(
+                    intent = "extract", domain = "ebay.com",
+                    url = "https://ebay.com/itm/test", urlPattern = "/itm/*",
+                    outcome = "success", actions = emptyList(),
+                ))
+            }
+
+            val result = store.list()
+            assertTrue(result.total >= 2, "Expected at least 2 entries, got ${result.total}")
+            assertEquals(1, result.page)
+        }
+
+        @Test
+        @DisplayName("list respects domain filter")
+        fun testListDomainFilter() = runBlocking {
+            store.saveFacts(KnowledgeFacts(
+                intent = "buy", domain = "amazon.com", urlPattern = "/dp/*",
+            ))
+            store.saveFacts(KnowledgeFacts(
+                intent = "search", domain = "github.com", urlPattern = "/search*",
+            ))
+
+            val amazonResult = store.list(domainFilter = "amazon")
+            assertEquals(1, amazonResult.total)
+            assertEquals("amazon.com", amazonResult.entries.first().domain)
+
+            val githubResult = store.list(domainFilter = "git")
+            assertEquals(1, githubResult.total)
+            assertEquals("github.com", githubResult.entries.first().domain)
+
+            val noneResult = store.list(domainFilter = "nonexistent")
+            assertEquals(0, noneResult.total)
+        }
+
+        @Test
+        @DisplayName("list respects intent filter")
+        fun testListIntentFilter() = runBlocking {
+            store.saveFacts(KnowledgeFacts(
+                intent = "buy", domain = "amazon.com", urlPattern = "/dp/*",
+            ))
+            store.saveFacts(KnowledgeFacts(
+                intent = "search", domain = "amazon.com", urlPattern = "/s?k=*",
+            ))
+
+            val buyResult = store.list(intentFilter = "buy")
+            assertEquals(1, buyResult.total)
+
+            val searchResult = store.list(intentFilter = "search")
+            assertEquals(1, searchResult.total)
+        }
+
+        @Test
+        @DisplayName("list pagination works correctly")
+        fun testListPagination() = runBlocking {
+            // Save 5 entries
+            for (i in 1..5) {
+                store.saveFacts(KnowledgeFacts(
+                    intent = "buy", domain = "site${i}.com", urlPattern = "/*",
+                ))
+            }
+
+            val page1 = store.list(page = 1, pageSize = 2)
+            assertEquals(5, page1.total)
+            assertEquals(2, page1.entries.size)
+            assertEquals(3, page1.totalPages)
+
+            val page2 = store.list(page = 2, pageSize = 2)
+            assertEquals(5, page2.total)
+            assertEquals(2, page2.entries.size)
+
+            val page3 = store.list(page = 3, pageSize = 2)
+            assertEquals(5, page3.total)
+            assertEquals(1, page3.entries.size)
+        }
+
+        @Test
+        @DisplayName("list entries are sorted by confidence descending")
+        fun testListSortedByConfidence() = runBlocking {
+            // Save facts with different confidence levels
+            store.saveFacts(KnowledgeFacts(
+                intent = "buy", domain = "low-conf.com", urlPattern = "/*",
+            ))
+            store.saveFacts(KnowledgeFacts(
+                intent = "buy", domain = "high-conf.com", urlPattern = "/*",
+            ))
+            // Add many successes to high-conf
+            repeat(20) {
+                store.updateStats(TraceRecord(
+                    intent = "buy", domain = "high-conf.com",
+                    url = "https://high-conf.com/test", urlPattern = "/*",
+                    outcome = "success", actions = emptyList(),
+                ))
+            }
+
+            val result = store.list()
+            if (result.entries.size >= 2) {
+                val first = result.entries[0]
+                val last = result.entries.last()
+                assertTrue(first.confidence >= last.confidence,
+                    "First entry confidence ${first.confidence} should be >= last ${last.confidence}")
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("query() fallback levels")
+    inner class QueryFallbacks {
+        @Test
+        @DisplayName("L2: URL pattern match within same domain")
+        fun testUrlPatternMatch() = runBlocking {
+            // Save facts with a specific URL pattern
+            val facts = KnowledgeFacts(
+                intent = "extract", domain = "amazon.com", urlPattern = "/dp/*",
+                status = VerificationStatus.CANDIDATE,
+                siteFacts = SiteFacts(domain = "amazon.com"),
+                selectors = mapOf("title" to VerifiedSelector(primary = "h1#title")),
+            )
+            store.saveFacts(facts)
+            repeat(3) {
+                store.updateStats(TraceRecord(
+                    intent = "extract", domain = "amazon.com",
+                    url = "https://amazon.com/dp/test$it", urlPattern = "/dp/*",
+                    outcome = "success", actions = emptyList(),
+                ))
+            }
+
+            // Query with a different intent but same domain+pattern → should match via L2
+            val result = store.query("https://amazon.com/dp/B0TEST", "read reviews")
+            // L2 URL pattern match should find facts even with different intent
+            assertNotEquals("P5", result.tier, "URL pattern match should find knowledge")
+            assertEquals("amazon.com", result.domain)
+        }
+
+        @Test
+        @DisplayName("L6: different domain returns cold start")
+        fun testDifferentDomainColdStart() {
+            val result = store.query("https://completely-different.com/page", "buy product")
+            assertEquals("P5", result.tier)
+        }
+    }
+
+    @Nested
+    @DisplayName("promoteToVerified() boundary transitions")
+    inner class PromoteBoundaries {
+        @Test
+        @DisplayName("promotes to CANDIDATE at 2+ successes, confidence >= 0.60")
+        fun testPromoteToCandidate() = runBlocking {
+            store.saveFacts(KnowledgeFacts.createHypothesis("buy", "amazon.com", "/dp/*"))
+
+            // Add exactly 2 successful traces (boundary)
+            repeat(2) { i ->
+                store.updateStats(TraceRecord(
+                    intent = "buy", domain = "amazon.com",
+                    url = "https://amazon.com/dp/test$i", urlPattern = "/dp/*",
+                    outcome = "success",
+                    actions = listOf(ActionStep(1, "click", selector = "#btn", result = "success")),
+                ))
+            }
+
+            val promoted = store.promoteToVerified("amazon.com", "buy")
+            assertNotNull(promoted)
+            // With 2 successes, should become at least CANDIDATE
+            assertTrue(promoted!!.status == VerificationStatus.CANDIDATE ||
+                promoted.status == VerificationStatus.VERIFIED,
+                "Expected CANDIDATE or VERIFIED but got ${promoted.status}")
+            assertTrue(promoted.promotionHistory.isNotEmpty())
+        }
+
+        @Test
+        @DisplayName("promotes to VERIFIED at 5+ successes, confidence >= 0.85")
+        fun testPromoteToVerified() = runBlocking {
+            store.saveFacts(KnowledgeFacts.createHypothesis("buy", "amazon.com", "/dp/*"))
+
+            // Add 5 successful traces
+            repeat(5) { i ->
+                store.updateStats(TraceRecord(
+                    intent = "buy", domain = "amazon.com",
+                    url = "https://amazon.com/dp/test$i", urlPattern = "/dp/*",
+                    outcome = "success",
+                    actions = listOf(ActionStep(1, "click", selector = "#btn", result = "success")),
+                ))
+            }
+
+            val promoted = store.promoteToVerified("amazon.com", "buy")
+            assertNotNull(promoted)
+            assertEquals(VerificationStatus.VERIFIED, promoted!!.status)
+        }
+
+        @Test
+        @DisplayName("no promotion when confidence too low")
+        fun testNoPromotionLowConfidence() = runBlocking {
+            store.saveFacts(KnowledgeFacts.createHypothesis("buy", "amazon.com", "/dp/*"))
+
+            // Add only failures
+            repeat(3) { i ->
+                store.updateStats(TraceRecord(
+                    intent = "buy", domain = "amazon.com",
+                    url = "https://amazon.com/dp/test$i", urlPattern = "/dp/*",
+                    outcome = "failure",
+                    failureCategory = "selector_drift",
+                    actions = emptyList(),
+                ))
+            }
+
+            val result = store.promoteToVerified("amazon.com", "buy")
+            // Should stay HYPOTHESIS or return null (no promotion)
+            if (result != null) {
+                assertEquals(VerificationStatus.HYPOTHESIS, result.status)
+            }
+        }
+
+        @Test
+        @DisplayName("promotion events accumulate in history")
+        fun testPromotionEventsHistory() = runBlocking {
+            store.saveFacts(KnowledgeFacts.createHypothesis("buy", "amazon.com", "/dp/*"))
+
+            // First promotion: HYPOTHESIS → CANDIDATE
+            repeat(3) { i ->
+                store.updateStats(TraceRecord(
+                    intent = "buy", domain = "amazon.com",
+                    url = "https://amazon.com/dp/test$i", urlPattern = "/dp/*",
+                    outcome = "success",
+                    actions = listOf(ActionStep(1, "click", selector = "#btn", result = "success")),
+                ))
+            }
+            val first = store.promoteToVerified("amazon.com", "buy")
+            assertNotNull(first)
+            val eventsAfterFirst = first!!.promotionHistory
+            assertTrue(eventsAfterFirst.size >= 2,
+                "Should have initial + promotion event, got ${eventsAfterFirst.size}")
+
+            // Second promotion: CANDIDATE → VERIFIED
+            repeat(5) { i ->
+                store.updateStats(TraceRecord(
+                    intent = "buy", domain = "amazon.com",
+                    url = "https://amazon.com/dp/more$i", urlPattern = "/dp/*",
+                    outcome = "success",
+                    actions = listOf(ActionStep(1, "click", selector = "#btn", result = "success")),
+                ))
+            }
+            val second = store.promoteToVerified("amazon.com", "buy")
+            assertNotNull(second)
+            assertTrue(second!!.promotionHistory.size > eventsAfterFirst.size,
+                "History should grow: ${second.promotionHistory.size} > $eventsAfterFirst.size")
+            // Last event should be to VERIFIED
+            val lastEvent = second.promotionHistory.last()
+            assertEquals("verified", lastEvent.to.lowercase())
+        }
+    }
+
+    @Nested
+    @DisplayName("Trace operations — edge cases")
+    inner class TraceEdgeCases {
+        @Test
+        @DisplayName("saveTrace auto-creates domain directory")
+        fun testSaveTraceCreatesDomainDir() {
+            val trace = TraceRecord(
+                intent = "search", domain = "new-domain.com",
+                url = "https://new-domain.com/search", urlPattern = "/search*",
+                outcome = "success",
+            )
+            val path = store.saveTrace(trace)
+            assertTrue(path.exists())
+            assertTrue(path.parent.exists()) // Domain directory created
+            assertEquals("new-domain.com", path.parent.fileName.toString())
+        }
+
+        @Test
+        @DisplayName("loadTrace returns null for invalid YAML")
+        fun testLoadTraceInvalidFile() {
+            val domainDir = tempDir.resolve("traces").resolve("test.com")
+            Files.createDirectories(domainDir)
+            val badFile = domainDir.resolve("bad.yaml")
+            Files.writeString(badFile, "::: this is not valid YAML :::")
+
+            val result = store.loadTrace(badFile)
+            assertNull(result)
+        }
+
+        @Test
+        @DisplayName("listTraces with domain filter")
+        fun testListTracesWithDomainFilter() {
+            store.saveTrace(TraceRecord(
+                intent = "buy", domain = "amazon.com",
+                url = "https://amazon.com/dp/1", urlPattern = "/dp/*",
+                outcome = "success",
+            ))
+            store.saveTrace(TraceRecord(
+                intent = "buy", domain = "amazon.com",
+                url = "https://amazon.com/dp/2", urlPattern = "/dp/*",
+                outcome = "success",
+            ))
+            store.saveTrace(TraceRecord(
+                intent = "search", domain = "ebay.com",
+                url = "https://ebay.com/sch/1", urlPattern = "/sch/*",
+                outcome = "success",
+            ))
+
+            val amazonTraces = store.listTraces(domain = "amazon.com")
+            assertEquals(2, amazonTraces.size)
+
+            val allTraces = store.listTraces()
+            assertTrue(allTraces.size >= 3)
+        }
+
+        @Test
+        @DisplayName("listTraces pagination")
+        fun testListTracesPagination() {
+            for (i in 1..5) {
+                store.saveTrace(TraceRecord(
+                    intent = "buy", domain = "amazon.com",
+                    url = "https://amazon.com/dp/$i", urlPattern = "/dp/*",
+                    outcome = "success",
+                ))
+            }
+
+            val page1 = store.listTraces(domain = "amazon.com", page = 1, pageSize = 2)
+            assertEquals(2, page1.size)
+
+            val page2 = store.listTraces(domain = "amazon.com", page = 2, pageSize = 2)
+            assertEquals(2, page2.size)
+
+            val page3 = store.listTraces(domain = "amazon.com", page = 3, pageSize = 2)
+            assertEquals(1, page3.size)
+        }
+    }
+
+    @Nested
+    @DisplayName("Stats operations — edge cases")
+    inner class StatsEdgeCases {
+        @Test
+        @DisplayName("updateStats across multiple domains keeps isolation")
+        fun testStatsDomainIsolation() {
+            store.updateStats(TraceRecord(
+                intent = "buy", domain = "amazon.com",
+                url = "https://amazon.com/dp/test", urlPattern = "/dp/*",
+                outcome = "success",
+                actions = listOf(ActionStep(1, "click", selector = "#amz-btn", result = "success")),
+            ))
+            store.updateStats(TraceRecord(
+                intent = "buy", domain = "ebay.com",
+                url = "https://ebay.com/itm/test", urlPattern = "/itm/*",
+                outcome = "success",
+                actions = listOf(ActionStep(1, "click", selector = "#ebay-btn", result = "success")),
+            ))
+
+            val amzStats = store.loadStats("amazon.com", "buy")
+            val ebayStats = store.loadStats("ebay.com", "buy")
+
+            assertEquals(1, amzStats.successes)
+            assertEquals("amazon.com", amzStats.domain)
+            assertTrue(amzStats.selectorStats.containsKey("#amz-btn"))
+
+            assertEquals(1, ebayStats.successes)
+            assertEquals("ebay.com", ebayStats.domain)
+            assertTrue(ebayStats.selectorStats.containsKey("#ebay-btn"))
+        }
+
+        @Test
+        @DisplayName("stats persist across loads")
+        fun testStatsPersistence() {
+            store.updateStats(TraceRecord(
+                intent = "buy", domain = "amazon.com",
+                url = "https://amazon.com/dp/test", urlPattern = "/dp/*",
+                outcome = "success",
+            ))
+            store.updateStats(TraceRecord(
+                intent = "buy", domain = "amazon.com",
+                url = "https://amazon.com/dp/test2", urlPattern = "/dp/*",
+                outcome = "success",
+            ))
+
+            val stats = store.loadStats("amazon.com", "buy")
+            assertEquals(2, stats.successes)
+            assertEquals(2, stats.totalAttempts)
+        }
+    }
+
+    @Nested
+    @DisplayName("Facts operations — edge cases")
+    inner class FactsEdgeCases {
+        @Test
+        @DisplayName("saveFacts overwrites existing facts")
+        fun testSaveFactsOverwrite() = runBlocking {
+            val v1 = KnowledgeFacts(
+                intent = "buy", domain = "amazon.com", urlPattern = "/dp/*",
+                status = VerificationStatus.HYPOTHESIS,
+            )
+            store.saveFacts(v1)
+
+            val v2 = KnowledgeFacts(
+                intent = "buy", domain = "amazon.com", urlPattern = "/dp/*",
+                status = VerificationStatus.CANDIDATE,
+                siteFacts = SiteFacts(domain = "amazon.com", siteFamily = "amazon-like"),
+            )
+            store.saveFacts(v2)
+
+            val loaded = store.loadFacts("amazon.com", "buy")
+            assertNotNull(loaded)
+            assertEquals(VerificationStatus.CANDIDATE, loaded!!.status)
+            assertEquals("amazon-like", loaded.siteFacts.siteFamily)
+        }
+
+        @Test
+        @DisplayName("loadFacts returns null for non-existent domain dir")
+        fun testLoadFactsMissingDir() {
+            assertNull(store.loadFacts("nonexistent.com", "any"))
+        }
+    }
+}

--- a/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/tools/experience/KnowledgeStorePersistenceFailureTest.kt
+++ b/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/tools/experience/KnowledgeStorePersistenceFailureTest.kt
@@ -1,0 +1,317 @@
+package ai.platon.pulsar.agentic.tools.experience
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+import java.time.Instant
+import kotlin.io.path.*
+import kotlin.test.*
+
+/**
+ * Tests for KnowledgeStore YAML persistence failure paths.
+ *
+ * Covers:
+ * - Corrupted YAML file recovery (loadFacts, loadStats, loadTrace)
+ * - Atomic write failure handling
+ * - KnowledgeStoreException
+ * - Intent sanitization in filenames
+ * - Edge cases in writeAtomicYaml
+ */
+@OptIn(ExperimentalPathApi::class)
+@DisplayName("KnowledgeStore — Persistence Failure Paths")
+class KnowledgeStorePersistenceFailureTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var store: KnowledgeStore
+
+    @BeforeEach
+    fun setUp() {
+        store = KnowledgeStore(tempDir)
+        store.initializeStore()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try { tempDir.deleteRecursively() } catch (_: Exception) {}
+    }
+
+    @Nested
+    @DisplayName("corrupted YAML recovery")
+    inner class CorruptedYamlRecovery {
+        @Test
+        @DisplayName("loadFacts returns null for malformed YAML")
+        fun testLoadFactsCorruptedYaml() {
+            val factsDir = tempDir.resolve("facts").resolve("amazon.com")
+            Files.createDirectories(factsDir)
+            val badFile = factsDir.resolve("buy.yaml")
+            Files.writeString(badFile, "intent: buy\ndomain: [unclosed bracket\n  - item1")
+
+            val result = store.loadFacts("amazon.com", "buy")
+            assertNull(result, "loadFacts should return null for corrupted YAML")
+        }
+
+        @Test
+        @DisplayName("loadFacts returns null for empty file")
+        fun testLoadFactsEmptyFile() {
+            val factsDir = tempDir.resolve("facts").resolve("amazon.com")
+            Files.createDirectories(factsDir)
+            val emptyFile = factsDir.resolve("buy.yaml")
+            Files.writeString(emptyFile, "")
+
+            val result = store.loadFacts("amazon.com", "buy")
+            assertNull(result, "loadFacts should return null for empty file")
+        }
+
+        @Test
+        @DisplayName("loadFacts returns null for non-YAML content")
+        fun testLoadFactsNonYamlContent() {
+            val factsDir = tempDir.resolve("facts").resolve("amazon.com")
+            Files.createDirectories(factsDir)
+            val badFile = factsDir.resolve("buy.yaml")
+            Files.writeString(badFile, "This is just plain text, not YAML at all!!!")
+
+            val result = store.loadFacts("amazon.com", "buy")
+            assertNull(result, "loadFacts should return null for non-YAML content")
+        }
+
+        @Test
+        @DisplayName("loadTrace returns null for corrupted file")
+        fun testLoadTraceCorruptedFile() {
+            val tracesDir = tempDir.resolve("traces").resolve("amazon.com")
+            Files.createDirectories(tracesDir)
+            val badFile = tracesDir.resolve("2026-01-01-bad.yaml")
+            Files.writeString(badFile, "::: not valid YAML ::: {{{")
+
+            val result = store.loadTrace(badFile)
+            assertNull(result, "loadTrace should return null for corrupted file")
+        }
+
+        @Test
+        @DisplayName("loadTrace returns null for empty file")
+        fun testLoadTraceEmptyFile() {
+            val tracesDir = tempDir.resolve("traces").resolve("amazon.com")
+            Files.createDirectories(tracesDir)
+            val emptyFile = tracesDir.resolve("2026-01-01-empty.yaml")
+            Files.writeString(emptyFile, "")
+
+            val result = store.loadTrace(emptyFile)
+            assertNull(result)
+        }
+
+        @Test
+        @DisplayName("loadStats returns fresh stats for corrupted file")
+        fun testLoadStatsCorruptedFile() {
+            val expDir = tempDir.resolve("experience").resolve("amazon.com")
+            Files.createDirectories(expDir)
+            val badFile = expDir.resolve("buy.yaml")
+            Files.writeString(badFile, "garbage {{{ not yaml :::")
+
+            val stats = store.loadStats("amazon.com", "buy")
+            assertNotNull(stats)
+            // Should return a fresh stats object, not throw
+            assertEquals(0, stats.totalAttempts)
+            assertEquals(0.50, stats.confidence)
+        }
+
+        @Test
+        @DisplayName("loadStats returns fresh stats for missing file")
+        fun testLoadStatsMissingFile() {
+            val stats = store.loadStats("nonexistent.com", "any_intent")
+            assertNotNull(stats)
+            assertEquals(0, stats.totalAttempts)
+            assertEquals("any_intent", stats.intent)
+        }
+
+        @Test
+        @DisplayName("loadFacts survives partially valid YAML with missing fields")
+        fun testLoadFactsPartialYaml() {
+            val factsDir = tempDir.resolve("facts").resolve("amazon.com")
+            Files.createDirectories(factsDir)
+            // Valid YAML but missing required fields
+            Files.writeString(factsDir.resolve("buy.yaml"), "some_unknown_field: 42\nanother: hello")
+
+            // Should not throw — handles missing fields gracefully
+            val result = store.loadFacts("amazon.com", "buy")
+            // May return null or a facts object with defaults — either is acceptable
+            // The key is that it doesn't throw
+        }
+    }
+
+    @Nested
+    @DisplayName("filename sanitization")
+    inner class FilenameSanitization {
+        @Test
+        @DisplayName("intents with special characters produce safe filenames")
+        fun testIntentSanitization() = runBlocking {
+            val intents = listOf(
+                "simple" to "simple",
+                "with spaces" to "with_spaces",
+                "with/slashes" to "with_slashes",
+                "with\\backslashes" to "with_backslashes",
+                "very-long-intent-name-that-exceeds-fifty-characters-and-should-be-truncated" to
+                    "very_long_intent_name_that_exceeds_fifty_charact",
+            )
+
+            for ((input, _) in intents) {
+                // Should not throw when saving facts with any of these intents
+                val facts = KnowledgeFacts(
+                    intent = input,
+                    domain = "test.com",
+                    urlPattern = "/*",
+                    status = VerificationStatus.HYPOTHESIS,
+                )
+                store.saveFacts(facts)
+            }
+
+            // Verify all were saved (by counting list results)
+            val result = store.list(pageSize = 100)
+            assertTrue(result.total >= intents.size,
+                "Expected at least ${intents.size} entries, got ${result.total}")
+        }
+    }
+
+    @Nested
+    @DisplayName("atomic write behavior")
+    inner class AtomicWriteBehavior {
+        @Test
+        @DisplayName("saveFacts followed by immediate loadFacts returns consistent data")
+        fun testSaveThenLoadConsistency() = runBlocking {
+            val facts = KnowledgeFacts(
+                intent = "buy", domain = "amazon.com", urlPattern = "/dp/*",
+                status = VerificationStatus.VERIFIED,
+                siteFacts = SiteFacts(domain = "amazon.com", siteFamily = "amazon-like"),
+                selectors = mapOf(
+                    "title" to VerifiedSelector(primary = "#productTitle", fallbacks = listOf("h1")),
+                ),
+                knownBlockers = listOf(
+                    BlockerInfo(type = "cookie_consent", selector = "#accept", action = "click"),
+                ),
+            )
+            store.saveFacts(facts)
+
+            val loaded = store.loadFacts("amazon.com", "buy")
+            assertNotNull(loaded)
+            assertEquals(VerificationStatus.VERIFIED, loaded!!.status)
+            assertEquals("amazon-like", loaded.siteFacts.siteFamily)
+            assertEquals("#productTitle", loaded.selectors["title"]?.primary)
+            assertEquals(listOf("h1"), loaded.selectors["title"]?.fallbacks)
+            assertEquals(1, loaded.knownBlockers.size)
+            assertEquals("cookie_consent", loaded.knownBlockers[0].type)
+        }
+
+        @Test
+        @DisplayName("tmp files are not left behind after successful write")
+        fun testNoTmpFilesLeftBehind() = runBlocking {
+            store.saveFacts(KnowledgeFacts(
+                intent = "buy", domain = "amazon.com", urlPattern = "/dp/*",
+            ))
+
+            val factsDir = tempDir.resolve("facts").resolve("amazon.com")
+            val tmpFiles = factsDir.listDirectoryEntries("*.tmp")
+            assertTrue(tmpFiles.isEmpty(),
+                "No .tmp files should remain after successful write, found: $tmpFiles")
+        }
+
+        @Test
+        @DisplayName("overwriting facts multiple times leaves clean state")
+        fun testMultipleOverwritesCleanState() = runBlocking {
+            repeat(5) { i ->
+                store.saveFacts(KnowledgeFacts(
+                    intent = "buy", domain = "amazon.com", urlPattern = "/dp/*",
+                    status = if (i >= 3) VerificationStatus.VERIFIED else VerificationStatus.HYPOTHESIS,
+                ))
+            }
+
+            val loaded = store.loadFacts("amazon.com", "buy")
+            assertNotNull(loaded)
+            assertEquals(VerificationStatus.VERIFIED, loaded!!.status)
+
+            // No tmp files
+            val factsDir = tempDir.resolve("facts").resolve("amazon.com")
+            val tmpFiles = factsDir.listDirectoryEntries("*.tmp")
+            assertTrue(tmpFiles.isEmpty(), "No tmp files should remain")
+            // Only the final yaml file
+            val yamlFiles = factsDir.listDirectoryEntries("*.yaml")
+            assertEquals(1, yamlFiles.size, "Only one facts file should exist")
+        }
+    }
+
+    @Nested
+    @DisplayName("KnowledgeStoreException")
+    inner class KnowledgeStoreExceptionTests {
+        @Test
+        @DisplayName("KnowledgeStoreException can be constructed with message")
+        fun testExceptionMessage() {
+            val ex = KnowledgeStoreException("test failure")
+            assertEquals("test failure", ex.message)
+            assertNull(ex.cause)
+        }
+
+        @Test
+        @DisplayName("KnowledgeStoreException can be constructed with message and cause")
+        fun testExceptionWithCause() {
+            val cause = RuntimeException("root cause")
+            val ex = KnowledgeStoreException("wrapped failure", cause)
+            assertEquals("wrapped failure", ex.message)
+            assertEquals(cause, ex.cause)
+        }
+    }
+
+    @Nested
+    @DisplayName("edge case: read-only filesystem behavior")
+    inner class ReadOnlyEdgeCases {
+        @Test
+        @DisplayName("loadFacts gracefully handles missing directory")
+        fun testLoadFactsMissingDirectory() {
+            // Ensure directory does not exist
+            val factsDir = tempDir.resolve("facts").resolve("nonexistent.com")
+            assertFalse(factsDir.exists())
+
+            val result = store.loadFacts("nonexistent.com", "any")
+            assertNull(result)
+        }
+
+        @Test
+        @DisplayName("list gracefully handles missing facts directory")
+        fun testListMissingFactsDirectory() {
+            // Remove the facts directory
+            tempDir.resolve("facts").deleteRecursively()
+
+            val result = store.list()
+            assertEquals(0, result.total)
+            assertEquals(0, result.entries.size)
+        }
+
+        @Test
+        @DisplayName("list gracefully handles unreadable YAML in facts directory")
+        fun testListSkipsUnreadableFiles() {
+            val factsDir = tempDir.resolve("facts").resolve("amazon.com")
+            Files.createDirectories(factsDir)
+            // Valid file
+            Files.writeString(factsDir.resolve("buy.yaml"), """
+                intent: buy
+                domain: amazon.com
+                url_pattern: /dp/*
+                status: hypothesis
+                site_facts:
+                  domain: amazon.com
+                page_facts: {}
+                selectors: {}
+            """.trimIndent())
+            // Invalid file
+            Files.writeString(factsDir.resolve("bad.yaml"), "{{{ not yaml :::")
+
+            // Should not throw — just skip the bad file
+            val result = store.list()
+            assertTrue(result.total >= 1, "Should find at least the valid entry")
+        }
+    }
+}

--- a/browser4-rest/src/test/kotlin/ai/platon/pulsar/rest/config/ExperienceToolMountConfigurationTest.kt
+++ b/browser4-rest/src/test/kotlin/ai/platon/pulsar/rest/config/ExperienceToolMountConfigurationTest.kt
@@ -1,0 +1,175 @@
+package ai.platon.pulsar.rest.config
+
+import ai.platon.pulsar.agentic.tools.ToolMount
+import ai.platon.pulsar.agentic.tools.experience.ExperienceToolExecutor
+import ai.platon.pulsar.agentic.tools.experience.KnowledgeStore
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.deleteRecursively
+import kotlin.test.*
+
+/**
+ * Tests for [ExperienceToolMountConfiguration] Spring bean wiring.
+ *
+ * Verifies:
+ * - KnowledgeStore bean creation and initialization
+ * - ExperienceToolExecutor bean creation with KnowledgeStore injection
+ * - ToolMount.getToolExecutors() returns the executor
+ * - All beans are usable (not just constructed)
+ */
+@OptIn(ExperimentalPathApi::class)
+@DisplayName("ExperienceToolMountConfiguration")
+class ExperienceToolMountConfigurationTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @AfterEach
+    fun tearDown() {
+        try { tempDir.deleteRecursively() } catch (_: Exception) {}
+    }
+
+    @Nested
+    @DisplayName("bean creation")
+    inner class BeanCreation {
+        @Test
+        @DisplayName("knowledgeStore bean is created and initialized")
+        fun testKnowledgeStoreBean() {
+            val config = ExperienceToolMountConfiguration()
+            val store = config.knowledgeStore()
+
+            assertNotNull(store)
+            // Should be usable immediately
+            val stats = store.loadStats("test.com", "buy")
+            assertNotNull(stats)
+            assertEquals(0.50, stats.confidence)
+        }
+
+        @Test
+        @DisplayName("experienceToolExecutor bean is created with KnowledgeStore")
+        fun testExperienceToolExecutorBean() {
+            val config = ExperienceToolMountConfiguration()
+            val store = config.knowledgeStore()
+            val executor = config.experienceToolExecutor(store)
+
+            assertNotNull(executor)
+            assertEquals("experience", executor.domain)
+            // Verify all four tool specs are registered
+            val specs = executor.getToolSpecs()
+            assertTrue(specs.containsKey("save"), "save tool spec should be registered")
+            assertTrue(specs.containsKey("query"), "query tool spec should be registered")
+            assertTrue(specs.containsKey("list"), "list tool spec should be registered")
+            assertTrue(specs.containsKey("deep_learn"), "deep_learn tool spec should be registered")
+        }
+
+        @Test
+        @DisplayName("repeated calls to knowledgeStore create independent instances")
+        fun testRepeatedKnowledgeStoreCalls() {
+            val config = ExperienceToolMountConfiguration()
+            val store1 = config.knowledgeStore()
+            val store2 = config.knowledgeStore()
+
+            // Each call creates a new instance (as expected from @Bean without singleton scope)
+            assertNotNull(store1)
+            assertNotNull(store2)
+        }
+
+        @Test
+        @DisplayName("ToolMount.getToolExecutors returns executor list")
+        fun testGetToolExecutors() {
+            val config = ExperienceToolMountConfiguration()
+            val executors = config.getToolExecutors()
+
+            assertNotNull(executors)
+            assertEquals(1, executors.size)
+            assertEquals("experience", executors[0].domain)
+        }
+    }
+
+    @Nested
+    @DisplayName("ToolMount interface contract")
+    inner class ToolMountContract {
+        @Test
+        @DisplayName("implements ToolMount interface")
+        fun testImplementsToolMount() {
+            val config = ExperienceToolMountConfiguration()
+            assertTrue(config is ToolMount, "Should implement ToolMount interface")
+        }
+
+        @Test
+        @DisplayName("getToolExecutors is non-empty and returns valid executors")
+        fun testGetToolExecutorsValid() {
+            val config = ExperienceToolMountConfiguration()
+            val executors = config.getToolExecutors()
+
+            assertTrue(executors.isNotEmpty(), "Should return at least one executor")
+            for (executor in executors) {
+                assertNotNull(executor.domain, "Executor should have a domain")
+                assertTrue(executor.domain.isNotBlank(), "Executor domain should not be blank")
+                assertTrue(executor.getToolSpecs().isNotEmpty(), "Executor should have tool specs")
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("end-to-end: config → executor → save/query")
+    inner class EndToEndViaConfig {
+        @Test
+        @DisplayName("executor from config can save and query")
+        fun testExecutorSaveAndQuery() = runBlocking {
+            val config = ExperienceToolMountConfiguration()
+            val store = config.knowledgeStore()
+            val executor = config.experienceToolExecutor(store)
+
+            val mapper = ai.platon.pulsar.common.serialize.json.pulsarObjectMapper()
+
+            // Save a trace
+            val trace = ai.platon.pulsar.agentic.tools.experience.ExecutionTrace(
+                url = "https://amazon.com/dp/test-product",
+                taskType = "extract_product_detail",
+                outcome = "success",
+            )
+            val saveResult = executor.callFunctionOn(
+                domain = "experience", functionName = "save",
+                args = mapOf(
+                    "url" to "https://amazon.com/dp/test-product",
+                    "trace" to mapper.writeValueAsString(trace),
+                    "outcome" to "success",
+                    "intent" to "buy product",
+                ),
+                receiver = store,
+            )
+            val saveJson = mapper.readTree(saveResult as String)
+            assertEquals(true, saveJson["saved"].asBoolean())
+
+            // Deep learn
+            executor.callFunctionOn(
+                domain = "experience", functionName = "deep_learn",
+                args = mapOf(
+                    "url" to "https://amazon.com/dp/test-product",
+                    "intent" to "buy product",
+                    "force" to "true",
+                ),
+                receiver = store,
+            )
+
+            // Query should find knowledge
+            val queryResult = executor.callFunctionOn(
+                domain = "experience", functionName = "query",
+                args = mapOf("url" to "https://amazon.com/dp/test-product", "intent" to "buy product"),
+                receiver = store,
+            )
+            val queryJson = mapper.readTree(queryResult as String)
+            assertNotEquals("P5", queryJson["tier"].asText())
+        }
+    }
+
+    private fun runBlocking(block: suspend () -> Unit) {
+        kotlinx.coroutines.runBlocking { block() }
+    }
+}

--- a/browser4-rest/src/test/kotlin/ai/platon/pulsar/rest/mcp/controller/MCPToolControllerExperienceE2ETest.kt
+++ b/browser4-rest/src/test/kotlin/ai/platon/pulsar/rest/mcp/controller/MCPToolControllerExperienceE2ETest.kt
@@ -1,0 +1,376 @@
+package ai.platon.pulsar.rest.mcp.controller
+
+import ai.platon.pulsar.agentic.AgenticSession
+import ai.platon.pulsar.agentic.agents.BasicBrowserAgent
+import ai.platon.pulsar.agentic.model.ToolCall
+import ai.platon.pulsar.agentic.tools.AgentToolManager
+import ai.platon.pulsar.agentic.model.ToolSpec
+import ai.platon.pulsar.rest.session.ManagedSession
+import ai.platon.pulsar.rest.session.PulsarSessionManager
+import jakarta.servlet.http.HttpServletResponse
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.springframework.http.HttpStatus
+import java.util.*
+
+/**
+ * Integration-level tests verifying that experience MCP tools
+ * (experience_save, experience_query, experience_list, experience_deep_learn)
+ * are correctly dispatched through the full MCP controller chain:
+ *
+ * POST /mcp/call-tool → alias normalization → argument normalization →
+ * tool resolution → AgentToolManager.execute()
+ */
+@DisplayName("MCPToolController — Experience Tool Dispatch")
+class MCPToolControllerExperienceE2ETest {
+
+    @Mock
+    private lateinit var sessionManager: PulsarSessionManager
+
+    @Mock
+    private lateinit var response: HttpServletResponse
+
+    @Mock
+    private lateinit var managedSession: ManagedSession
+
+    @Mock
+    private lateinit var agenticSession: AgenticSession
+
+    @Mock
+    private lateinit var basicBrowserAgent: BasicBrowserAgent
+
+    @Mock
+    private lateinit var agentToolManager: AgentToolManager
+
+    private lateinit var controller: MCPToolController
+
+    private val sessionId = UUID.randomUUID().toString()
+
+    private val registeredToolSpecs = mutableMapOf<String, MutableMap<String, ToolSpec>>()
+
+    @BeforeEach
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        controller = MCPToolController(sessionManager)
+        registeredToolSpecs.clear()
+
+        `when`(sessionManager.getSession(sessionId)).thenReturn(managedSession)
+        `when`(managedSession.agenticSession).thenReturn(agenticSession)
+        `when`(agenticSession.companionAgent).thenReturn(basicBrowserAgent)
+        `when`(basicBrowserAgent.agentToolManager).thenReturn(agentToolManager)
+    }
+
+    private fun capture(captor: ArgumentCaptor<ToolCall>): ToolCall {
+        captor.capture()
+        return ToolCall("dummy", "dummy")
+    }
+
+    private fun mockExperienceTool(method: String) {
+        registeredToolSpecs
+            .getOrPut("experience") { mutableMapOf() }
+            .put(method, ToolSpec(domain = "experience", method = method, description = "desc"))
+
+        `when`(agentToolManager.getAllToolSpecs()).thenReturn(registeredToolSpecs)
+
+        runBlocking {
+            `when`(agentToolManager.execute(any())).thenReturn(
+                ai.platon.pulsar.agentic.model.ToolCallResult(
+                    evaluate = ai.platon.pulsar.agentic.model.TcEvaluate(value = "ok")
+                )
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("experience_save dispatch")
+    inner class ExperienceSaveDispatch {
+        @Test
+        @DisplayName("dispatches to experience.save with normalized arguments")
+        fun dispatchesToExperienceSave() = runBlocking {
+            mockExperienceTool("save")
+
+            val request = MCPToolCallRequest(
+                tool = "experience_save",
+                arguments = mapOf(
+                    "sessionId" to sessionId,
+                    "url" to "https://amazon.com/dp/test-product",
+                    "trace" to """{"steps":[{"sequence":1,"action":"click","selector":"#btn","result":"success"}],"outcome":"success"}""",
+                    "outcome" to "success",
+                    "intent" to "buy product",
+                    "task_type" to "extract_product_detail",
+                )
+            )
+
+            val result = controller.callTool(request, response)
+            assertEquals(HttpStatus.OK, result.statusCode)
+
+            val captor = ArgumentCaptor.forClass(ToolCall::class.java)
+            Mockito.verify(agentToolManager).execute(capture(captor))
+            val toolCall = captor.value
+
+            assertEquals("experience", toolCall.domain)
+            assertEquals("save", toolCall.method)
+            assertEquals("https://amazon.com/dp/test-product", toolCall.arguments["url"])
+            assertFalse(toolCall.arguments.containsKey("sessionId"),
+                "sessionId should be stripped from arguments")
+        }
+
+        @Test
+        @DisplayName("dispatches failure save with outcome=failure")
+        fun dispatchesFailureSave() = runBlocking {
+            mockExperienceTool("save")
+
+            val request = MCPToolCallRequest(
+                tool = "experience_save",
+                arguments = mapOf(
+                    "sessionId" to sessionId,
+                    "url" to "https://blocked.com/search",
+                    "trace" to """{"steps":[],"outcome":"failure","error_message":"CAPTCHA detected"}""",
+                    "outcome" to "failure",
+                    "intent" to "search product",
+                )
+            )
+
+            val result = controller.callTool(request, response)
+            assertEquals(HttpStatus.OK, result.statusCode)
+
+            val captor = ArgumentCaptor.forClass(ToolCall::class.java)
+            Mockito.verify(agentToolManager).execute(capture(captor))
+            val toolCall = captor.value
+
+            assertEquals("experience", toolCall.domain)
+            assertEquals("save", toolCall.method)
+            assertEquals("failure", toolCall.arguments["outcome"])
+        }
+    }
+
+    @Nested
+    @DisplayName("experience_query dispatch")
+    inner class ExperienceQueryDispatch {
+        @Test
+        @DisplayName("dispatches to experience.query with URL and intent")
+        fun dispatchesToExperienceQuery() = runBlocking {
+            mockExperienceTool("query")
+
+            val request = MCPToolCallRequest(
+                tool = "experience_query",
+                arguments = mapOf(
+                    "sessionId" to sessionId,
+                    "url" to "https://amazon.com/dp/test",
+                    "intent" to "extract product details",
+                )
+            )
+
+            val result = controller.callTool(request, response)
+            assertEquals(HttpStatus.OK, result.statusCode)
+
+            val captor = ArgumentCaptor.forClass(ToolCall::class.java)
+            Mockito.verify(agentToolManager).execute(capture(captor))
+            val toolCall = captor.value
+
+            assertEquals("experience", toolCall.domain)
+            assertEquals("query", toolCall.method)
+            assertEquals("https://amazon.com/dp/test", toolCall.arguments["url"])
+            assertNotNull(toolCall.arguments["intent"])
+            assertFalse(toolCall.arguments.containsKey("sessionId"))
+        }
+
+        @Test
+        @DisplayName("dispatches query without intent (optional)")
+        fun dispatchesQueryWithoutIntent() = runBlocking {
+            mockExperienceTool("query")
+
+            val request = MCPToolCallRequest(
+                tool = "experience_query",
+                arguments = mapOf(
+                    "sessionId" to sessionId,
+                    "url" to "https://example.com/page",
+                )
+            )
+
+            val result = controller.callTool(request, response)
+            assertEquals(HttpStatus.OK, result.statusCode)
+
+            val captor = ArgumentCaptor.forClass(ToolCall::class.java)
+            Mockito.verify(agentToolManager).execute(capture(captor))
+            assertEquals("experience", captor.value.domain)
+            assertEquals("query", captor.value.method)
+        }
+    }
+
+    @Nested
+    @DisplayName("experience_list dispatch")
+    inner class ExperienceListDispatch {
+        @Test
+        @DisplayName("dispatches to experience.list with no arguments")
+        fun dispatchesToExperienceList() = runBlocking {
+            mockExperienceTool("list")
+
+            val request = MCPToolCallRequest(
+                tool = "experience_list",
+                arguments = mapOf("sessionId" to sessionId)
+            )
+
+            val result = controller.callTool(request, response)
+            assertEquals(HttpStatus.OK, result.statusCode)
+
+            val captor = ArgumentCaptor.forClass(ToolCall::class.java)
+            Mockito.verify(agentToolManager).execute(capture(captor))
+            val toolCall = captor.value
+
+            assertEquals("experience", toolCall.domain)
+            assertEquals("list", toolCall.method)
+            assertFalse(toolCall.arguments.containsKey("sessionId"))
+        }
+
+        @Test
+        @DisplayName("dispatches to experience.list with filter and pagination")
+        fun dispatchesListWithFilters() = runBlocking {
+            mockExperienceTool("list")
+
+            val request = MCPToolCallRequest(
+                tool = "experience_list",
+                arguments = mapOf(
+                    "sessionId" to sessionId,
+                    "filter" to "amazon",
+                    "intent_filter" to "buy",
+                    "page" to 2,
+                    "page_size" to 10,
+                )
+            )
+
+            val result = controller.callTool(request, response)
+            assertEquals(HttpStatus.OK, result.statusCode)
+
+            val captor = ArgumentCaptor.forClass(ToolCall::class.java)
+            Mockito.verify(agentToolManager).execute(capture(captor))
+            val toolCall = captor.value
+
+            assertEquals("experience", toolCall.domain)
+            assertEquals("list", toolCall.method)
+            assertEquals("amazon", toolCall.arguments["filter"])
+            assertEquals("buy", toolCall.arguments["intent_filter"])
+        }
+    }
+
+    @Nested
+    @DisplayName("experience_deep_learn dispatch")
+    inner class ExperienceDeepLearnDispatch {
+        @Test
+        @DisplayName("dispatches to experience.deep_learn with url and intent")
+        fun dispatchesToExperienceDeepLearn() = runBlocking {
+            mockExperienceTool("deep_learn")
+
+            val request = MCPToolCallRequest(
+                tool = "experience_deep_learn",
+                arguments = mapOf(
+                    "sessionId" to sessionId,
+                    "url" to "https://amazon.com/dp/test",
+                    "intent" to "extract product details",
+                )
+            )
+
+            val result = controller.callTool(request, response)
+            assertEquals(HttpStatus.OK, result.statusCode)
+
+            val captor = ArgumentCaptor.forClass(ToolCall::class.java)
+            Mockito.verify(agentToolManager).execute(capture(captor))
+            val toolCall = captor.value
+
+            assertEquals("experience", toolCall.domain)
+            assertEquals("deep_learn", toolCall.method)
+            assertFalse(toolCall.arguments.containsKey("sessionId"))
+        }
+
+        @Test
+        @DisplayName("dispatches deep_learn with force=true")
+        fun dispatchesDeepLearnWithForce() = runBlocking {
+            mockExperienceTool("deep_learn")
+
+            val request = MCPToolCallRequest(
+                tool = "experience_deep_learn",
+                arguments = mapOf(
+                    "sessionId" to sessionId,
+                    "url" to "https://amazon.com/dp/test",
+                    "intent" to "extract product details",
+                    "force" to true,
+                )
+            )
+
+            val result = controller.callTool(request, response)
+            assertEquals(HttpStatus.OK, result.statusCode)
+
+            val captor = ArgumentCaptor.forClass(ToolCall::class.java)
+            Mockito.verify(agentToolManager).execute(capture(captor))
+            val toolCall = captor.value
+
+            assertEquals(true, toolCall.arguments["force"])
+        }
+    }
+
+    @Nested
+    @DisplayName("error handling")
+    inner class ErrorHandling {
+        @Test
+        @DisplayName("unknown experience method returns error")
+        fun unknownMethodReturnsError() = runBlocking {
+            // Don't mock any tool — the lookup will fail
+            val request = MCPToolCallRequest(
+                tool = "experience_unknown",
+                arguments = mapOf("sessionId" to sessionId)
+            )
+
+            val result = controller.callTool(request, response)
+            // Should be an error response
+            assertNotNull(result.body)
+        }
+
+        @Test
+        @DisplayName("all four experience tools coexist with other domain tools")
+        fun allExperienceToolsCoexist() = runBlocking {
+            mockExperienceTool("save")
+            mockExperienceTool("query")
+            mockExperienceTool("list")
+            mockExperienceTool("deep_learn")
+            // Also register a non-experience tool
+            registeredToolSpecs
+                .getOrPut("tab") { mutableMapOf() }
+                .put("click", ToolSpec(domain = "tab", method = "click", description = "desc"))
+
+            `when`(agentToolManager.getAllToolSpecs()).thenReturn(registeredToolSpecs)
+            runBlocking {
+                `when`(agentToolManager.execute(any())).thenReturn(
+                    ai.platon.pulsar.agentic.model.ToolCallResult(
+                        evaluate = ai.platon.pulsar.agentic.model.TcEvaluate(value = "ok")
+                    )
+                )
+            }
+
+            // experience_list should dispatch correctly even with other tools present
+            val request = MCPToolCallRequest(
+                tool = "experience_list",
+                arguments = mapOf("sessionId" to sessionId)
+            )
+
+            val result = controller.callTool(request, response)
+            assertEquals(HttpStatus.OK, result.statusCode)
+
+            val captor = ArgumentCaptor.forClass(ToolCall::class.java)
+            Mockito.verify(agentToolManager).execute(capture(captor))
+            assertEquals("experience", captor.value.domain)
+            assertEquals("list", captor.value.method)
+        }
+    }
+}

--- a/cli/browser4-cli/src/commands.rs
+++ b/cli/browser4-cli/src/commands.rs
@@ -3209,6 +3209,101 @@ pub fn all_commands() -> Vec<CommandDef> {
                 json!({ "description": get_str(args, "description").unwrap_or_default() })
             },
         },
+        // ---- Experience ----
+        CommandDef {
+            name: "experience-save",
+            description: "Save a task execution trace to the progressive experience memory. Records the steps taken, selectors used, and outcome so future tasks on the same domain can replay them.",
+            category: Category::Skills,
+            hidden: false,
+            batch_supported: false,
+            args: &[
+                ArgDef { name: "url", description: "The URL the task operated on", optional: false },
+                ArgDef { name: "trace", description: "JSON-encoded execution trace (steps, selectors, extraction results)", optional: false },
+            ],
+            options: &[
+                OptionDef { name: "outcome", description: "Task outcome: success (default) or failure", is_bool: false, short: None },
+                OptionDef { name: "intent", description: "Free-text description of what the task was trying to do", is_bool: false, short: None },
+                OptionDef { name: "task-type", description: "Canonical task type (e.g. extract_product_detail, search, navigate)", is_bool: false, short: None },
+            ],
+            e2e_coverage: E2eCoverage::Excluded,
+            tool_name_fn: |_| "experience_save".to_string(),
+            tool_params_fn: |args| {
+                let trace_str = get_str(args, "trace").unwrap_or_default();
+                let mut params = json!({ "url": get_str(args, "url").unwrap_or_default(), "trace": trace_str });
+                if let Some(outcome) = get_opt_str(args, "outcome") { params["outcome"] = json!(outcome); }
+                if let Some(intent) = get_opt_str(args, "intent") { params["intent"] = json!(intent); }
+                if let Some(task_type) = get_opt_str(args, "task-type") { params["task_type"] = json!(task_type); }
+                params
+            },
+        },
+        CommandDef {
+            name: "experience-query",
+            description: "Query the progressive experience memory for stored knowledge about a domain. Returns selectors, blockers, interaction hints, and confidence tier. Called automatically before every agent task.",
+            category: Category::Skills,
+            hidden: false,
+            batch_supported: false,
+            args: &[
+                ArgDef { name: "url", description: "The target URL to query knowledge for", optional: false },
+            ],
+            options: &[
+                OptionDef { name: "intent", description: "Free-text intent description for classification", is_bool: false, short: None },
+            ],
+            e2e_coverage: E2eCoverage::Excluded,
+            tool_name_fn: |_| "experience_query".to_string(),
+            tool_params_fn: |args| {
+                let mut params = json!({ "url": get_str(args, "url").unwrap_or_default() });
+                if let Some(intent) = get_opt_str(args, "intent") { params["intent"] = json!(intent); }
+                params
+            },
+        },
+        CommandDef {
+            name: "experience-list",
+            description: "List stored knowledge entries from the progressive experience memory. Filter by domain or intent to inspect what the system has learned.",
+            category: Category::Skills,
+            hidden: false,
+            batch_supported: false,
+            args: &[],
+            options: &[
+                OptionDef { name: "filter", description: "Filter by domain (partial case-insensitive match)", is_bool: false, short: None },
+                OptionDef { name: "intent-filter", description: "Filter by intent (partial case-insensitive match)", is_bool: false, short: None },
+                OptionDef { name: "page", description: "Page number (default: 1)", is_bool: false, short: None },
+                OptionDef { name: "page-size", description: "Results per page (default: 20, max: 100)", is_bool: false, short: None },
+            ],
+            e2e_coverage: E2eCoverage::Excluded,
+            tool_name_fn: |_| "experience_list".to_string(),
+            tool_params_fn: |args| {
+                let mut params = json!({});
+                if let Some(filter) = get_opt_str(args, "filter") { params["filter"] = json!(filter); }
+                if let Some(intent_filter) = get_opt_str(args, "intent-filter") { params["intent_filter"] = json!(intent_filter); }
+                if let Some(page) = get_opt_str(args, "page") { params["page"] = json!(page); }
+                if let Some(page_size) = get_opt_str(args, "page-size") { params["page_size"] = json!(page_size); }
+                params
+            },
+        },
+        CommandDef {
+            name: "experience-deep-learn",
+            description: "Run deep learning analysis on stored experience traces. Builds or updates verified knowledge facts (selectors, blockers, page structure). Promotes knowledge from hypothesis to verified when confidence thresholds are met.",
+            category: Category::Skills,
+            hidden: false,
+            batch_supported: false,
+            args: &[
+                ArgDef { name: "url", description: "The target URL to analyze", optional: false },
+                ArgDef { name: "intent", description: "Free-text intent description for classification", optional: false },
+            ],
+            options: &[
+                OptionDef { name: "force", description: "Force deep learning even if confidence is already high", is_bool: true, short: None },
+            ],
+            e2e_coverage: E2eCoverage::Excluded,
+            tool_name_fn: |_| "experience_deep_learn".to_string(),
+            tool_params_fn: |args| {
+                let mut params = json!({
+                    "url": get_str(args, "url").unwrap_or_default(),
+                    "intent": get_str(args, "intent").unwrap_or_default(),
+                });
+                if let Some(force) = get_bool(args, "force") { params["force"] = json!(force); }
+                params
+            },
+        },
     ]
 }
 
@@ -3296,6 +3391,10 @@ mod tests {
             "plugin-install",
             "plugin-remove",
             "act",
+            "experience-save",
+            "experience-query",
+            "experience-list",
+            "experience-deep-learn",
         ] {
             assert!(map.contains_key(*expected), "Missing command: {}", expected);
         }
@@ -6223,5 +6322,185 @@ mod tests {
         let cmd = map.get("webdb-normalize").unwrap();
         assert_eq!(cmd.args.len(), 1);
         assert_eq!(cmd.args[0].name, "url");
+    }
+
+    // =========================================================================
+    // experience command tests
+    // =========================================================================
+
+    #[test]
+    fn test_experience_save_tool_name() {
+        let map = commands_map();
+        let cmd = map.get("experience-save").unwrap();
+        assert_eq!((cmd.tool_name_fn)(&HashMap::new()), "experience_save");
+    }
+
+    #[test]
+    fn test_experience_save_params_with_all_options() {
+        let map = commands_map();
+        let cmd = map.get("experience-save").unwrap();
+        let mut args = HashMap::new();
+        args.insert("url".to_string(), json!("https://amazon.com/dp/test"));
+        args.insert("trace".to_string(), json!(r#"{"steps":[],"outcome":"success"}"#));
+        args.insert("outcome".to_string(), json!("failure"));
+        args.insert("intent".to_string(), json!("buy product"));
+        args.insert("task-type".to_string(), json!("extract_product_detail"));
+
+        let params = (cmd.tool_params_fn)(&args);
+        assert_eq!(params["url"], "https://amazon.com/dp/test");
+        assert_eq!(params["trace"], r#"{"steps":[],"outcome":"success"}"#);
+        assert_eq!(params["outcome"], "failure");
+        assert_eq!(params["intent"], "buy product");
+        assert_eq!(params["task_type"], "extract_product_detail");
+    }
+
+    #[test]
+    fn test_experience_save_params_minimal() {
+        let map = commands_map();
+        let cmd = map.get("experience-save").unwrap();
+        let mut args = HashMap::new();
+        args.insert("url".to_string(), json!("https://example.com"));
+        args.insert("trace".to_string(), json!("{}"));
+
+        let params = (cmd.tool_params_fn)(&args);
+        assert_eq!(params["url"], "https://example.com");
+        assert_eq!(params["trace"], "{}");
+        assert!(params.get("outcome").is_none());
+    }
+
+    #[test]
+    fn test_experience_query_tool_name() {
+        let map = commands_map();
+        let cmd = map.get("experience-query").unwrap();
+        assert_eq!((cmd.tool_name_fn)(&HashMap::new()), "experience_query");
+    }
+
+    #[test]
+    fn test_experience_query_params_with_intent() {
+        let map = commands_map();
+        let cmd = map.get("experience-query").unwrap();
+        let mut args = HashMap::new();
+        args.insert("url".to_string(), json!("https://amazon.com/dp/test"));
+        args.insert("intent".to_string(), json!("extract product details"));
+
+        let params = (cmd.tool_params_fn)(&args);
+        assert_eq!(params["url"], "https://amazon.com/dp/test");
+        assert_eq!(params["intent"], "extract product details");
+    }
+
+    #[test]
+    fn test_experience_query_params_without_intent() {
+        let map = commands_map();
+        let cmd = map.get("experience-query").unwrap();
+        let mut args = HashMap::new();
+        args.insert("url".to_string(), json!("https://example.com"));
+
+        let params = (cmd.tool_params_fn)(&args);
+        assert_eq!(params["url"], "https://example.com");
+        assert!(params.get("intent").is_none());
+    }
+
+    #[test]
+    fn test_experience_list_tool_name() {
+        let map = commands_map();
+        let cmd = map.get("experience-list").unwrap();
+        assert_eq!((cmd.tool_name_fn)(&HashMap::new()), "experience_list");
+    }
+
+    #[test]
+    fn test_experience_list_params_empty() {
+        let map = commands_map();
+        let cmd = map.get("experience-list").unwrap();
+        let params = (cmd.tool_params_fn)(&HashMap::new());
+        assert_eq!(params, json!({}));
+    }
+
+    #[test]
+    fn test_experience_list_params_with_filters() {
+        let map = commands_map();
+        let cmd = map.get("experience-list").unwrap();
+        let mut args = HashMap::new();
+        args.insert("filter".to_string(), json!("amazon"));
+        args.insert("intent-filter".to_string(), json!("buy"));
+        args.insert("page".to_string(), json!("3"));
+        args.insert("page-size".to_string(), json!("50"));
+
+        let params = (cmd.tool_params_fn)(&args);
+        assert_eq!(params["filter"], "amazon");
+        assert_eq!(params["intent_filter"], "buy");
+        assert_eq!(params["page"], "3");
+        assert_eq!(params["page_size"], "50");
+    }
+
+    #[test]
+    fn test_experience_deep_learn_tool_name() {
+        let map = commands_map();
+        let cmd = map.get("experience-deep-learn").unwrap();
+        assert_eq!((cmd.tool_name_fn)(&HashMap::new()), "experience_deep_learn");
+    }
+
+    #[test]
+    fn test_experience_deep_learn_params_required_only() {
+        let map = commands_map();
+        let cmd = map.get("experience-deep-learn").unwrap();
+        let mut args = HashMap::new();
+        args.insert("url".to_string(), json!("https://amazon.com/dp/test"));
+        args.insert("intent".to_string(), json!("buy product"));
+
+        let params = (cmd.tool_params_fn)(&args);
+        assert_eq!(params["url"], "https://amazon.com/dp/test");
+        assert_eq!(params["intent"], "buy product");
+        assert!(params.get("force").is_none());
+    }
+
+    #[test]
+    fn test_experience_deep_learn_params_with_force() {
+        let map = commands_map();
+        let cmd = map.get("experience-deep-learn").unwrap();
+        let mut args = HashMap::new();
+        args.insert("url".to_string(), json!("https://amazon.com"));
+        args.insert("intent".to_string(), json!("extract"));
+        args.insert("force".to_string(), json!(true));
+
+        let params = (cmd.tool_params_fn)(&args);
+        assert_eq!(params["force"], true);
+    }
+
+    #[test]
+    fn test_experience_commands_have_correct_category() {
+        let map = commands_map();
+        for name in &[
+            "experience-save",
+            "experience-query",
+            "experience-list",
+            "experience-deep-learn",
+        ] {
+            let cmd = map.get(*name).unwrap();
+            assert_eq!(cmd.category.as_str(), "skills", "{} should be in Skills category", name);
+        }
+    }
+
+    #[test]
+    fn test_experience_commands_have_required_args_defined() {
+        let map = commands_map();
+
+        let save = map.get("experience-save").unwrap();
+        assert_eq!(save.args.len(), 2);
+        assert!(!save.args[0].optional, "url should be required");
+        assert_eq!(save.args[0].name, "url");
+        assert!(!save.args[1].optional, "trace should be required");
+        assert_eq!(save.args[1].name, "trace");
+
+        let query = map.get("experience-query").unwrap();
+        assert_eq!(query.args.len(), 1);
+        assert!(!query.args[0].optional, "url should be required");
+
+        let list = map.get("experience-list").unwrap();
+        assert!(list.args.is_empty());
+
+        let dl = map.get("experience-deep-learn").unwrap();
+        assert_eq!(dl.args.len(), 2);
+        assert!(!dl.args[0].optional, "url should be required");
+        assert!(!dl.args[1].optional, "intent should be required");
     }
 }

--- a/cli/browser4-cli/src/main.rs
+++ b/cli/browser4-cli/src/main.rs
@@ -8701,6 +8701,138 @@ async fn handle_crawl_list(
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Experience handlers
+// ---------------------------------------------------------------------------
+
+async fn handle_experience_save(
+    client: &Client,
+    base_url: &str,
+    tool_params: &Value,
+) -> Result<(), String> {
+    let result = call_tool(client, base_url, "experience_save", tool_params.clone()).await?;
+    let parsed: Value = serde_json::from_str(&result).unwrap_or_default();
+    cli_println!("{}", serde_json::to_string_pretty(&parsed).unwrap_or(result));
+    json_field("result", parsed);
+    Ok(())
+}
+
+async fn handle_experience_query(
+    client: &Client,
+    base_url: &str,
+    tool_params: &Value,
+) -> Result<(), String> {
+    let result = call_tool(client, base_url, "experience_query", tool_params.clone()).await?;
+    let parsed: Value = serde_json::from_str(&result).unwrap_or_default();
+    if let (Some(tier), Some(confidence)) = (
+        parsed.get("tier").and_then(|v| v.as_str()),
+        parsed.get("confidence").and_then(|v| v.as_f64()),
+    ) {
+        cli_println!("Tier: {}  |  Confidence: {:.3}", tier, confidence);
+    }
+    if let Some(summary) = parsed.get("summary").and_then(|v| v.as_str()) {
+        cli_println!("{}", summary);
+    }
+    if let Some(selectors) = parsed.get("primary_selectors").and_then(|v| v.as_object()) {
+        if !selectors.is_empty() {
+            cli_println!("\nPrimary selectors:");
+            for (k, v) in selectors {
+                cli_println!("  {}: {}", k, v.as_str().unwrap_or("-"));
+            }
+        }
+    }
+    if let Some(warnings) = parsed.get("warnings").and_then(|v| v.as_array()) {
+        if !warnings.is_empty() {
+            cli_println!("\nWarnings:");
+            for w in warnings {
+                cli_println!("  ! {}", w.as_str().unwrap_or("-"));
+            }
+        }
+    }
+    json_field("result", parsed);
+    Ok(())
+}
+
+async fn handle_experience_list(
+    client: &Client,
+    base_url: &str,
+    tool_params: &Value,
+) -> Result<(), String> {
+    let result = call_tool(client, base_url, "experience_list", tool_params.clone()).await?;
+    let parsed: Value = serde_json::from_str(&result).unwrap_or_default();
+    let total = parsed.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
+    let page = parsed.get("page").and_then(|v| v.as_u64()).unwrap_or(1);
+    let total_pages = parsed.get("total_pages").and_then(|v| v.as_u64()).unwrap_or(1);
+    cli_println!("Experience entries: {} total (page {}/{})", total, page, total_pages);
+    if let Some(entries) = parsed.get("entries").and_then(|v| v.as_array()) {
+        if entries.is_empty() {
+            cli_println!("No knowledge entries found. Run an agent task to build experience, then use 'experience-deep-learn' to promote facts.");
+        } else {
+            cli_println!("{:<25}  {:<20}  {:<6}  {:<10}  {:<10}  {}", "DOMAIN", "INTENT", "TIER", "CONF", "STATUS", "SITE TYPES");
+            cli_println!("{}", "-".repeat(110));
+            for entry in entries {
+                let domain = entry.get("domain").and_then(|v| v.as_str()).unwrap_or("-");
+                let intent = entry.get("intent").and_then(|v| v.as_str()).unwrap_or("-");
+                let tier = entry.get("retrieval_tier").and_then(|v| v.as_str()).unwrap_or("-");
+                let confidence = entry.get("confidence").and_then(|v| v.as_f64()).unwrap_or(0.0);
+                let status = entry.get("status").and_then(|v| v.as_str()).unwrap_or("-");
+                let site_types = entry.get("site_types").and_then(|v| v.as_array())
+                    .map(|a| a.iter().filter_map(|s| s.as_str()).collect::<Vec<_>>().join(", "))
+                    .unwrap_or_default();
+                cli_println!(
+                    "{:<25}  {:<20}  {:<6}  {:<10.3}  {:<10}  {}",
+                    truncate_str(domain, 25),
+                    truncate_str(intent, 20),
+                    tier,
+                    confidence,
+                    status,
+                    site_types,
+                );
+            }
+        }
+    }
+    json_field("result", parsed);
+    Ok(())
+}
+
+async fn handle_experience_deep_learn(
+    client: &Client,
+    base_url: &str,
+    tool_params: &Value,
+) -> Result<(), String> {
+    cli_println!("Running deep learning analysis (this may take a few seconds)...");
+    let result = call_tool(client, base_url, "experience_deep_learn", tool_params.clone()).await?;
+    let parsed: Value = serde_json::from_str(&result).unwrap_or_default();
+    if let Some(completed) = parsed.get("completed").and_then(|v| v.as_bool()) {
+        if !completed {
+            cli_println!("Deep learning skipped — confidence already high. Use --force to override.");
+        } else {
+            let promoted = parsed.get("promoted").and_then(|v| v.as_bool()).unwrap_or(false);
+            let status_after = parsed.get("status_after").and_then(|v| v.as_str()).unwrap_or("-");
+            let confidence = parsed.get("new_confidence").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            let selectors = parsed.get("selectors_found").and_then(|v| v.as_i64()).unwrap_or(0);
+            cli_println!("Deep learning complete.");
+            cli_println!("  Status: {} (promoted: {})", status_after, promoted);
+            cli_println!("  Confidence: {:.3}", confidence);
+            cli_println!("  Selectors found: {}", selectors);
+        }
+    }
+    if let Some(msg) = parsed.get("message").and_then(|v| v.as_str()) {
+        cli_println!("{}", msg);
+    }
+    json_field("result", parsed);
+    Ok(())
+}
+
+/// Truncate a string to at most `max_len` characters, appending "…" if truncated.
+fn truncate_str(s: &str, max_len: usize) -> String {
+    if s.chars().count() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}…", &s.chars().take(max_len.saturating_sub(1)).collect::<String>())
+    }
+}
+
 async fn handle_crawl_status(
     client: &Client,
     base_url: &str,
@@ -13042,9 +13174,21 @@ fn rewrite_prefixed_command(args: &[String]) -> Option<Vec<String>> {
         }
         return None;
     }
+    // `experience deep learn` is a two-level subcommand — rewrite to the flat
+    // `experience-deep-learn` form so the dispatch matches it correctly.
+    if prefix == "experience" && sub == "deep" {
+        if let Some(inner) = args.get(2) {
+            if inner == "learn" {
+                let mut rewritten = vec!["experience-deep-learn".to_string()];
+                rewritten.extend(args[3..].iter().cloned());
+                return Some(rewritten);
+            }
+        }
+    }
     let rewritten_command = match prefix {
         "swarm" => format!("swarm-{}", sub),
         "agent" => format!("agent-{}", sub),
+        "experience" => format!("experience-{}", sub),
         "htmlsnapshot" => format!("htmlsnapshot-{}", sub),
         "snapshot" => format!("snapshot-{}", sub),
         "skills" => format!("skills-{}", sub),
@@ -13089,6 +13233,10 @@ fn preferred_spaced_command_form(command: &str) -> Option<&'static str> {
         "htmlsnapshot-inspect" => Some("htmlsnapshot inspect"),
         "doctor-log" => Some("doctor log"),
         "doctor-metrics" => Some("doctor metrics"),
+        "experience-save" => Some("experience save"),
+        "experience-query" => Some("experience query"),
+        "experience-list" => Some("experience list"),
+        "experience-deep-learn" => Some("experience deep learn"),
         "plugin-list" => Some("plugin list"),
         "plugin-info" => Some("plugin info"),
         "plugin-install" => Some("plugin install"),
@@ -15028,6 +15176,18 @@ async fn run(
         "crawl-list" => {
             handle_crawl_list(&client, &base_url, &tool_params).await?;
         }
+        "experience-save" => {
+            handle_experience_save(&client, &base_url, &tool_params).await?;
+        }
+        "experience-query" => {
+            handle_experience_query(&client, &base_url, &tool_params).await?;
+        }
+        "experience-list" => {
+            handle_experience_list(&client, &base_url, &tool_params).await?;
+        }
+        "experience-deep-learn" => {
+            handle_experience_deep_learn(&client, &base_url, &tool_params).await?;
+        }
         "loop" => {
             handle_loop(&client, &base_url, global).await?;
         }
@@ -16565,6 +16725,55 @@ mod tests {
         assert_eq!(compiled.steps[0]["tool"], json!("browser_press_key"));
         assert_eq!(compiled.steps[0]["arguments"]["ref"], json!("#type-target"));
         assert_eq!(compiled.steps[0]["arguments"]["key"], json!("!"));
+    }
+
+    #[test]
+    fn rewrite_prefixed_command_handles_experience_save() {
+        let rewritten = rewrite_prefixed_command(&[
+            "experience".to_string(),
+            "save".to_string(),
+            "https://example.com".to_string(),
+            r#"{"steps":[]}"#.to_string(),
+        ])
+        .unwrap();
+        assert_eq!(rewritten[0], "experience-save");
+        assert_eq!(rewritten[1], "https://example.com");
+        assert_eq!(rewritten[2], r#"{"steps":[]}"#);
+    }
+
+    #[test]
+    fn rewrite_prefixed_command_handles_experience_deep_learn() {
+        let rewritten = rewrite_prefixed_command(&[
+            "experience".to_string(),
+            "deep".to_string(),
+            "learn".to_string(),
+            "https://example.com".to_string(),
+            "extract product".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(rewritten[0], "experience-deep-learn");
+        assert_eq!(rewritten[1], "https://example.com");
+        assert_eq!(rewritten[2], "extract product");
+    }
+
+    #[test]
+    fn preferred_spaced_command_form_includes_experience_commands() {
+        assert_eq!(
+            preferred_spaced_command_form("experience-save"),
+            Some("experience save")
+        );
+        assert_eq!(
+            preferred_spaced_command_form("experience-query"),
+            Some("experience query")
+        );
+        assert_eq!(
+            preferred_spaced_command_form("experience-list"),
+            Some("experience list")
+        );
+        assert_eq!(
+            preferred_spaced_command_form("experience-deep-learn"),
+            Some("experience deep learn")
+        );
     }
 
     #[test]

--- a/docs/experience-memory.md
+++ b/docs/experience-memory.md
@@ -1,177 +1,340 @@
 ---
-title: "Experience Memory — Architecture & Implementation Guide"
-description: "End-to-end guide for the Progressive Experience Memory learning system: knowledge store layout, MCP tool usage, retrieval chain, confidence model, and implementation patterns."
-tier: procedure
+title: "Experience System — Progressive Experience Memory (PEM)"
+description: "Complete reference for Browser4's self-learning knowledge system: three-tier storage, four MCP tools, confidence model, intent classification, failure taxonomy, and retrieval fallback chain."
+tier: reference
 ---
 
-# Progressive Experience Memory (PEM) — Implementation Guide
+# Progressive Experience Memory (PEM)
 
-## Quick Start
+The Experience system makes Browser4 **progressively smarter**: each completed task deposits reusable knowledge so future tasks — identical, similar, or on similar sites — complete faster with fewer steps.
 
-The experience tools (`experience_query`, `experience_save`, `experience_list`) are **MCP tools** called by the agent during `browser4-cli agent run` — they are not standalone CLI subcommands.
+## Overview
 
-```bash
-# 1. Run the agent with a task — it calls experience_query before starting
-#    and experience_save after completion, automatically persisting knowledge
-browser4-cli agent run "Go to https://amazon.com/dp/B0CXJ1NT4B and extract product details"
-
-# 2. Inspect stored knowledge entries
-browser4-cli agent run "List experience knowledge entries for amazon"
-```
-
-## When to Use
-
-Use `experience_query` **before every task** — it's a no-op on cold start (returns P5 with no penalty). Use `experience_save` **after every task** (success or failure) — knowledge compounds with each visit.
-
-When NOT to use:
-- Throwaway test sessions (skip the `experience_save` call or omit it entirely)
-- Tasks on sensitive/authenticated pages where selectors embed user data (the redaction layer in Phase 2+ will handle this automatically)
-
-## How It Works
-
-The PEM system has **three MCP tools** that read/write a **file-backed YAML knowledge store**. On task completion, the agent calls `experience_save` which:
-
-1. Persists the raw execution trace to `.traces/<domain>/<timestamp>-<task_type>.yaml`
-2. Extracts the domain from the URL
-3. Normalizes the URL (strips query params, `www.`, fragments)
-4. Derives a URL pattern (replaces high-cardinality path segments with `*`)
-5. Creates or updates a `KnowledgeEntry` in `sites/<domain>.yaml`
-6. Updates the in-memory index (`knowledge/.index.yaml`)
-7. Returns a save summary with confidence scores
-
-On the next visit to the same domain, `experience_query`:
-1. Normalizes the input URL
-2. Extracts the domain and looks up the index
-3. Finds the most specific matching URL pattern
-4. Loads the `KnowledgeEntry` from `sites/<domain>.yaml`
-5. Returns stored selectors, steps, extraction patterns, and blocker awareness
-
-## Architecture
-
-### Four-Layer Knowledge Model
+PEM is a persistent, file-backed knowledge layer implemented in Kotlin (`browser4-agentic`). It is exposed as an MCP tool domain (`"experience"`) with four tools, registered into the dispatch chain via Spring Boot auto-configuration in `browser4-rest`.
 
 ```
-L1: Site Profile         — domain, site_types, auth_pattern, load_strategy
-L2: Page Schema          — url_pattern, selectors_ranked, wpsi_landmarks
-L3: Task Playbook        — steps, extraction_fields, success_criteria, fallbacks
-L4: Abstract Patterns    — cross-site generalizations (Phase 4+)
+                  ┌──────────────────────────┐
+                  │   MCP Tool Controller    │
+                  │   (browser4-rest)         │
+                  └──────────┬───────────────┘
+                             │ dispatch
+                  ┌──────────▼───────────────┐
+                  │  ExperienceToolExecutor  │
+                  │  domain = "experience"    │
+                  │                          │
+                  │  save / query / list     │
+                  │  deep_learn              │
+                  └──────────┬───────────────┘
+                             │
+                  ┌──────────▼───────────────┐
+                  │     KnowledgeStore       │
+                  │  (file-backed YAML)      │
+                  │                          │
+                  │  traces/   experience/   │
+                  │  facts/    patterns/     │
+                  └──────────────────────────┘
 ```
 
-### Implementation Modules
+## Three-Tier Knowledge Model
 
-All PEM code lives in `browser4-agentic` under package `ai.platon.pulsar.agentic.tools.experience`:
+Knowledge flows through three progressively refined layers:
 
-| File | Purpose |
-|------|---------|
-| `ExperienceModels.kt` | Data classes: ExecutionTrace, SiteProfile, PageSchema, TaskPlaybook, KnowledgeEntry, ConfidenceScore, TaskType |
-| `KnowledgeStore.kt` | YAML file I/O with atomic rename, index management, domain-indexed storage |
-| `UrlNormalizer.kt` | URL normalization, pattern matching, specificity scoring |
-| `ExperienceToolExecutor.kt` | MCP tool executor (domain="experience") extending AbstractToolExecutor |
-| `config/ExperienceAutoConfiguration.kt` | Spring Boot auto-configuration registering executor via CustomToolRegistry |
+```
+TraceRecord              ExperienceStats           KnowledgeFacts
+(raw, 30d TTL,           (mutable, aggregated,     (verified, immutable,
+ never replayed)          confidence source)        used for replay)
+───────────────────────▶ ───────────────────────▶ ───────────────────
+ saveTrace()              updateStats()              saveFacts()
+                                                     promoteToVerified()
+```
 
-### Registration
+| Layer | Directory | Mutability | Purpose |
+|-------|-----------|------------|---------|
+| **Traces** | `traces/<domain>/` | Immutable, 30d TTL | Raw execution records — exactly what happened |
+| **Stats** | `experience/<domain>/` | Mutable, continuously updated | Aggregated success/failure counts; confidence derived here |
+| **Facts** | `facts/<domain>/` | Immutable once VERIFIED | Authoritative selectors, blockers, interaction hints for replay |
 
-The executor is registered at startup via Spring auto-configuration (`META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`). It implements `ToolMount` so the `PluginManager` automatically wires it into the MCP dispatch chain. No changes to `AgentToolManager` or `MCPToolController` are needed.
+A fourth layer — **Patterns** (`patterns/families/`, `patterns/categories/`, `patterns/universal/`) — stores cross-site generalizations promoted from multiple domains.
 
-### Concurrency Model
+## Four MCP Tools
 
-- **Readers never lock** — atomic rename guarantees consistent view
-- **Writers to the same domain serialize** via per-domain `Mutex`
-- **Writers to different domains run concurrently**
+### experience_save — Fast Learning
+
+Records a task trace and updates statistics. Runs in ~tens of milliseconds. No analysis tools execute.
+
+| Argument | Required | Type | Description |
+|----------|----------|------|-------------|
+| `url` | Yes | String | The URL the task operated on |
+| `trace` | Yes | String (JSON) | JSON-encoded `ExecutionTrace` (steps, selectors, extraction results) |
+| `outcome` | No | String | `"success"` (default) or `"failure"` |
+| `intent` | No | String | Free-text description of what the task was trying to do |
+| `task_type` | No | String | One of the 12 canonical task types |
+
+**What it does:**
+
+1. Parses the trace JSON into an `ExecutionTrace`
+2. Normalizes the URL, extracts domain and URL pattern
+3. Classifies intent via `Intent.classify()` (keyword scoring)
+4. For failures, classifies the error via `FailureCategory.classify()`
+5. Writes a `TraceRecord` to `traces/<domain>/<timestamp>-<intent>.yaml`
+6. Updates `ExperienceStats` via `withSuccess()` or `withFailure()`
+
+**Returns:** `ExperienceSaveResult` — `{saved, domain, intent, confidence, retrieval_tier, failure_category, message}`
+
+### experience_query — Intent-Based Retrieval
+
+Queries stored knowledge before a task starts. Runs in ~single-digit milliseconds.
+
+| Argument | Required | Type | Description |
+|----------|----------|------|-------------|
+| `url` | Yes | String | The target URL |
+| `intent` | No | String | Free-text intent description for classification |
+
+**6-level resolution fallback:**
+
+1. **(domain, intent)** — exact match on domain + classified intent
+2. **(domain, url_pattern)** — match by URL pattern within same domain
+3. **(site_family, intent)** — cross-site family pattern (e.g., amazon-like sites)
+4. **(site_category, intent)** — cross-category pattern (e.g., all marketplaces)
+5. **(site_universal, intent)** — universal pattern (e.g., all ecommerce)
+6. **Cold start (P5)** — no knowledge; full discovery required
+
+**Returns:** `ExperienceQueryResult` — `{tier, confidence, domain, intent, url_pattern, primary_selectors, known_blockers, warnings, status}`
+
+### experience_list — Diagnostic Browser
+
+Lists stored knowledge entries with pagination and filtering.
+
+| Argument | Required | Type | Default | Description |
+|----------|----------|------|---------|-------------|
+| `filter` | No | String | — | Filter by domain (partial case-insensitive match) |
+| `intent_filter` | No | String | — | Filter by intent (partial case-insensitive match) |
+| `page` | No | Int | 1 | Page number |
+| `page_size` | No | Int | 20 | Results per page (max 100) |
+
+**Returns:** `ExperienceListResult` — `{total, page, page_size, total_pages, entries[]}`
+
+### experience_deep_learn — Deep Learning
+
+Runs analysis tools to build or update `KnowledgeFacts`. Explicit call — runs in ~seconds.
+
+| Argument | Required | Type | Default | Description |
+|----------|----------|------|---------|-------------|
+| `url` | Yes | String | — | The target URL |
+| `intent` | Yes | String | — | Free-text intent description |
+| `force` | No | Boolean | false | Bypass sampling; run even if confidence ≥ 0.90 |
+
+**What it does:**
+
+1. Classifies intent, loads current stats and facts
+2. **Sampling check:** skips if confidence ≥ 0.90 and `force=false`
+3. Loads the most recent successful trace for the domain
+4. Creates `KnowledgeFacts` as `HYPOTHESIS` (first run) or updates existing
+5. Calls `promoteToVerified()` — promotes if thresholds are met
+6. Saves facts to `facts/<domain>/<intent>.yaml`
+
+**Returns:** `DeepLearnResult` — `{completed, domain, intent, status_before, status_after, promoted, new_confidence, selectors_found, message}`
 
 ## Confidence Model
 
+Confidence is **computed on-the-fly** from `ExperienceStats` — it is never stored.
+
 ```
-confidence = α × success_ratio + (1 - α) × recency_factor
+confidence = α × success_ratio + (1 − α) × recency_factor
 
 Where:
-  success_ratio = (success_count + 1) / (success_count + failure_count + 2)  [Laplace-smoothed]
-  recency_factor = 0.5 ^ (days_since_last_verification / 60)  [60-day half-life]
-  α = 0.7
+  success_ratio  = (successes + 1) / (successes + failures + 2)    [Laplace smoothing]
+  recency_factor = 0.5 ^ (days_since_last_update / 60)            [60-day half-life]
+  α              = 0.7
 
-Special cases:
-  first verified save → fixed 0.50
-  cap → 0.95, floor → 0.05
+Constants:
+  Initial (first save)  → 0.50
+  Cap                    → 0.95
+  Floor                  → 0.05
 ```
 
-### Retrieval Tiers by Confidence
+### Retrieval Tiers
 
-| Tier | Range | Behavior |
-|------|-------|----------|
-| P1 | ≥ 0.85 | Direct replay — stored steps used without verification |
-| P2 | 0.60–0.84 | Verify-before-replay — each selector validated via `htmlsnapshot get` |
-| P3 | 0.40–0.59 | Hint mode — playbook suggests, full discovery runs |
-| P4 | < 0.40 | Advisory — knowledge surfaced as suggestion only |
-| P5 | No data | Cold start — `htmlsnapshot inspect` auto-discovery |
+| Tier | Confidence | Behavior |
+|------|-----------|----------|
+| **P1** Direct replay | ≥ 0.85 | Stored steps used without verification. Selectors used as-is. |
+| **P2** Verify-before-replay | 0.60–0.84 | Each selector validated before use. |
+| **P3** Hint mode | 0.40–0.59 | Knowledge suggests candidates; full discovery runs. |
+| **P4** Advisory | < 0.40 | Knowledge surfaced as suggestion only. |
+| **P5** Cold start | No data | No prior knowledge. Full exploration required. |
 
-## Task Types
+Tiers can be **degraded** by failure categories. If any recorded failure has `degradeRetrieval = true` (e.g., `ANTI_BOT`), the tier drops one level: P1 → P2, P2 → P3.
 
-| Type | Default Criteria |
-|------|-----------------|
-| `extract_product_list` | `field_not_null: title` AND `row_count_gt: 0` |
-| `extract_product_detail` | `field_not_null: title` |
-| `extract_article` | `field_not_null: title` AND `field_not_null: body` |
-| `search` | `row_count_gt: 0` |
-| `add_to_cart` | `selector_visible` for cart confirmation |
-| `fill_form` | `url_pattern: changed` |
-| `login` | `url_pattern: changed` |
-| `checkout` | `url_pattern` matches `/order/confirmation` |
-| `extract_table` | `row_count_gt: 0` AND `field_not_null: col_0` |
-| `navigate` | `url_pattern` matches target |
-| `download_file` | Non-zero file size |
-| `monitor_change` | Changed value from baseline |
+## Verification Pipeline
+
+Knowledge progresses through four verification states:
+
+```
+HYPOTHESIS  ──▶  CANDIDATE  ──▶  VERIFIED (locked, immutable)
+                                       │
+                                  CONTESTED (disconfirmations > confirmations)
+```
+
+| Status | Trigger | Confidence Required | Replay Behavior |
+|--------|---------|---------------------|-----------------|
+| **HYPOTHESIS** | Initial `deep_learn` pass | Any | Not used for replay |
+| **CANDIDATE** | `promoteToVerified()` | ≥ 0.60, ≥ 2 successes | Verify-before-replay |
+| **VERIFIED** | `promoteToVerified()` | ≥ 0.85, ≥ 5 successes | Direct replay; selectors LOCKED |
+| **CONTESTED** | Disconfirmations exceed confirmations | — | Under review |
+
+### Promotion thresholds (from `KnowledgeStore.promoteToVerified()`)
+
+- `confidence ≥ 0.85 AND successes ≥ 5` → **VERIFIED**
+- `confidence ≥ 0.60 AND successes ≥ 2` → **CANDIDATE**
+- Otherwise → stays at current status
+
+## Intent Classification
+
+Twelve intents, each with canonical action sequences used for keyword matching:
+
+| Intent | Canonical Actions | Trigger Keywords |
+|--------|-------------------|------------------|
+| `BUY` | search → select → add_to_cart → checkout | buy, purchase, order, add to cart, cheapest |
+| `SEARCH` | navigate → type → submit → extract | search, find, lookup, query |
+| `BOOK` | search → select → fill_form → confirm | book, reserve, appointment, ticket, flight, hotel |
+| `EXTRACT` | navigate → extract | extract, scrape, get data, fetch, collect |
+| `COMPARE` | search → extract → compare | compare, vs, versus, difference between |
+| `DOWNLOAD` | navigate → click → wait | download, save file, export |
+| `READ` | navigate → scroll → extract | read, article, news, blog, post |
+| `LOGIN` | navigate → fill → submit | login, sign in, authenticate |
+| `CHECKOUT` | review → fill → confirm | checkout, place order, confirm purchase |
+| `FILL_FORM` | navigate → fill → submit | fill, form, register, sign up, subscribe |
+| `MONITOR` | navigate → check → compare | monitor, watch, track, alert, notify |
+| `OTHER` | — | Fallback when no keywords match |
+
+Classification uses **keyword scoring**: canonical action words in the text score +2, display-name match scores +3, intent-specific keywords score +4. Highest-scoring intent wins.
+
+## Failure Taxonomy
+
+Twelve failure categories, each with recoverability and recovery hints:
+
+| Category | Recoverable | Degrades Tier | Detection Keywords |
+|----------|-------------|---------------|--------------------|
+| `SELECTOR_DRIFT` | Yes | No | selector, element not found, no such element |
+| `VISUAL_DRIFT` | Yes | No | not visible, not clickable, hidden, obscured |
+| `NETWORK` | Yes | No | timeout, network, connection, econnrefused |
+| `AUTH_REQUIRED` | No | No | login, sign in, 401, 403, unauthorized |
+| `PERMISSION_DENIED` | No | No | permission denied, not allowed, admin only |
+| `OVERLAY_BLOCKED` | Yes | No | overlay, modal, popup, cookie, consent |
+| `TIMING` | Yes | No | wait, loading, not ready, pending |
+| **`ANTI_BOT`** | **No** | **Yes** | captcha, recaptcha, bot detection, unusual traffic |
+| `LAZY_LOADING` | Yes | No | lazy, data-src, placeholder, skeleton |
+| `AB_EXPERIMENT` | Yes | No | a/b, variant, experiment, split test |
+| `UNEXPECTED_REDIRECT` | Yes | No | redirect, moved, url changed |
+| `UNKNOWN` | No | No | Fallback |
+
+Only `ANTI_BOT` degrades the retrieval tier. Failures are classified by keyword matching against the error message and the last attempted selector context.
 
 ## URL Normalization
 
-URLs are normalized before storage and matching:
-
-```
-Input:  https://www.amazon.com/dp/B0CXJ1NT4B/ref=sr_1_1?keywords=laptop&qid=1234567
+```text
+Input:  https://www.amazon.com/dp/B0CXJ1NT4B/ref=sr_1_1?keywords=laptop&qid=1234567#reviews
 Output: amazon.com/dp/B0CXJ1NT4B
 ```
 
-Rules:
-1. Strip `www.` prefix
-2. Strip trailing slash
+### Rules (in order)
+
+1. Strip `www.` prefix from host
+2. Strip trailing slash from path
 3. Strip fragment (`#section`)
-4. Strip query params except semantically significant ones (`?q=`, `?id=`, `?page=`, `?k=`)
-5. Replace high-cardinality path segments with `*` in URL patterns
+4. Strip query parameters **except** semantically significant ones: `q`, `id`, `page`, `k`
+5. URL patterns replace high-cardinality path segments with `*` (segments with digits, length > 4)
+
+### Pattern Matching
+
+Patterns like `/dp/*` match concrete URLs like `/dp/B0CXJ1NT4B`. When multiple patterns match, the one with the highest **specificity** (count of literal, non-wildcard segments) wins.
 
 ## Storage Layout
 
 ```
 {knowledge_dir}/
-├── sites/
-│   ├── amazon.com.yaml
-│   ├── ebay.com.yaml
-│   └── github.com.yaml
-├── .index.yaml
-├── .traces/
-│   └── amazon.com/
-│       ├── 2026-0717-142530-extract_product_list.yaml
-│       └── 2026-0717-143045-search.yaml
-└── .archive/
+├── traces/
+│   └── <domain>/
+│       └── 2026-07-26-143025-<intent>.yaml    ← TraceRecord (immutable, 30d TTL)
+├── experience/
+│   └── <domain>/
+│       └── <intent>.yaml                       ← ExperienceStats (mutable)
+├── facts/
+│   └── <domain>/
+│       └── <intent>.yaml                       ← KnowledgeFacts (verified, immutable)
+├── patterns/
+│   ├── families/<name>.yaml                    ← L4: site-family patterns
+│   ├── categories/<name>.yaml                  ← L4: site-category patterns
+│   └── universal/<name>.yaml                   ← L4: universal patterns
+├── .index.yaml                                 ← in-memory index (regenerated lazily)
+└── .archive/                                   ← evicted artifacts
 ```
 
-## Future Phases
+## Concurrency Model
 
-| Phase | Status | Key Features |
-|-------|--------|-------------|
-| Phase 1 | ✓ Implemented | Trace & Replay, URL pattern matching, knowledge store |
-| Phase 2 | Planned | `--with-experience` flags for inspect/summary, fast-path skip, stability scoring |
-| Phase 3 | Planned | PowerCSS `:expr()` analysis, X-SQL extraction query capture, P2 retrieval |
-| Phase 4 | Planned | Cross-site generalization, WPSI signature matching, geometric fingerprints |
-| Phase 5 | Planned | Continuous learning, time-decay staleness, periodic probes, automated rollback |
+- **Readers never lock** — atomic rename (write to `.tmp` → `fsync` → rename) guarantees a consistent view
+- **Writers to the same domain serialize** via per-domain `Mutex`
+- **Writers to different domains run concurrently**
 
 ## Configuration
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `browser4.experience.enabled` | `true` | Enable/disable the PEM system |
-| `knowledge.dir` | `$AGENT_BASE_DIR/knowledge` | Knowledge store root directory |
+| `browser4.experience.enabled` | `true` | Enable/disable the entire PEM system |
+| `knowledge.dir` | `knowledge/` (relative) | Knowledge store root directory |
 
-## Reference
+The `ExperienceToolMountConfiguration` in `browser4-rest` registers the executor via Spring Boot auto-configuration (conditional on `browser4.experience.enabled=true`). The executor implements `ToolMount`, so `PluginManager` automatically wires it into both the MCP dispatcher and the LLM agent tool system.
 
-- [Design proposal (v2)](../coworker/plan/feature/evolve/synthesis-proposed-solution.md) — Full 2300-line technical specification
+## Source Files
+
+All in `browser4-agentic/src/main/kotlin/ai/platon/pulsar/agentic/tools/experience/`:
+
+| File | Key Types | Purpose |
+|------|-----------|---------|
+| `ExperienceToolExecutor.kt` | `ExperienceToolExecutor` | MCP tool executor — dispatches `save`, `query`, `list`, `deep_learn` |
+| `ExperienceModels.kt` | `ExecutionTrace`, `ExperienceQueryResult`, `ExperienceSaveResult`, `DeepLearnResult`, `ExperienceListResult`, `ActionStep`, `SelectorEntry`, `TaskType`, `SuccessCriteria` | All data classes for tool I/O |
+| `ExperienceStats.kt` | `ExperienceStats`, `SelectorStats` | Aggregated statistics with confidence and tier computation |
+| `KnowledgeStore.kt` | `KnowledgeStore` | File-backed YAML store with atomic writes, query resolution, and promotion |
+| `KnowledgeFacts.kt` | `KnowledgeFacts`, `SiteFacts`, `PageFacts`, `VerifiedSelector`, `BlockerInfo`, `PromotionEvent`, `PatternPromotion` | Verified immutable knowledge layer |
+| `IntentModels.kt` | `Intent`, `FailureCategory`, `VerificationStatus`, `PromotionLevel` | Classification enums with keyword-based matching |
+| `TraceRecord.kt` | `TraceRecord`, `PageState` | Raw immutable execution record |
+| `UrlNormalizer.kt` | `UrlNormalizer` | URL normalization, pattern matching, specificity scoring |
+
+### Spring Configuration
+
+| File | Purpose |
+|------|---------|
+| `browser4-rest/.../config/ExperienceToolMountConfiguration.kt` | Registers `KnowledgeStore` and `ExperienceToolExecutor` as Spring beans, implements `ToolMount` |
+
+## Core Loop
+
+```
+Before task ──▶ experience_query ──▶ Get stored selectors, steps, blockers
+    │                                      │
+    ▼                                      ▼
+Execute task                        P1: Replay directly
+    │                               P2: Verify then replay
+    ▼                               P3: Hint mode (verify all)
+After task  ──▶ experience_save ──▶ P4: Advisory only
+    │                               P5: Cold start (no knowledge)
+    ▼
+(periodic) ──▶ experience_deep_learn ──▶ Build facts, promote status
+```
+
+## Promotion Hierarchy (Cross-Site)
+
+Patterns ascend a 4-level hierarchy as they're confirmed across more sites:
+
+| Level | Min Sites | Example |
+|-------|-----------|---------|
+| **SITE** | 1 | Selectors for `amazon.com/dp/*` |
+| **FAMILY** | 2 | Shared across amazon-like sites (amazon, ebay, walmart) |
+| **CATEGORY** | 3 | Shared across all marketplaces (amazon, ebay, etsy) |
+| **UNIVERSAL** | 4 | Shared across all ecommerce sites |
+
+A `PatternPromotion` can advance when `confirmed_sites ≥ minSitesRequired` and the confirmation ratio ≥ 75%.
+
+## Related Documents
+
 - [Skill: browser4-experience](../skills/browser4-experience/SKILL.md) — Agent-facing usage guide
-- [AGENTS.md](../AGENTS.md) — Code conventions and development patterns
+- [CLAUDE.md](../CLAUDE.md) — Project context and conventions


### PR DESCRIPTION
## Summary

Two-part PR for the Progressive Experience Memory (PEM) system:

### 1. Documentation rewrite (`docs/experience-memory.md`)

Rewrites the Experience system reference to accurately reflect the current implementation:
- **4 MCP tools** (save, query, list, deep_learn) — was 3
- **Three-tier knowledge model** (traces → stats → facts)
- Exact confidence formula with constants from `ExperienceStats.kt`
- 12 intents and 12 failure categories with keyword tables
- Verification pipeline (HYPOTHESIS → CANDIDATE → VERIFIED → CONTESTED)
- Cross-site promotion hierarchy (SITE → FAMILY → CATEGORY → UNIVERSAL)
- Revised storage layout matching the v2 architecture

### 2. CLI subcommands (`cli/browser4-cli/`)

Adds four CLI subcommands so users can interact with the experience system directly:

| Command | Purpose |
|---|---|
| `experience-save <url> <trace>` | Persist a task trace (with --outcome, --intent, --task-type) |
| `experience-query <url>` | Query stored knowledge for a domain (with --intent) |
| `experience-list` | List all stored knowledge (with --filter, --intent-filter, --page, --page-size) |
| `experience-deep-learn <url> <intent>` | Run deep learning analysis (with --force) |

Each command dispatches through `POST /mcp/call-tool` to the existing backend MCP tools.

**Files changed:** `commands.rs` (+95, 4 new CommandDefs), `main.rs` (+145, 4 handlers + dispatch + truncate helper)

All 715 existing CLI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)