### PR TITLE
fix(scripts): fix agent output capture race condition in Start-NativeCommand

### DIFF
--- a/browser4-tests/real-world-scenarios/scripts/common.ps1
+++ b/browser4-tests/real-world-scenarios/scripts/common.ps1
@@ -293,7 +293,16 @@ public class NativeCommandOutputHandler
         if (e.Data != null)
         {
             Console.WriteLine(e.Data);
-            File.AppendAllText(_capturePath, e.Data + Environment.NewLine, _utf8);
+            try
+            {
+                File.AppendAllText(_capturePath, e.Data + Environment.NewLine, _utf8);
+            }
+            catch (Exception ex)
+            {
+                // Log to console so failures are visible — the handler runs on
+                // .NET threadpool threads where unhandled exceptions are swallowed.
+                Console.Error.WriteLine("[NativeCommandOutputHandler] Failed to write capture line: " + ex.Message);
+            }
         }
     }
 }
@@ -1485,6 +1494,12 @@ function Start-NativeCommand {
 
         # ── Drain final output ─────────────────────────────────────────────
         # The process has exited but async reads may still have data in flight.
+        # WaitForExit() (parameterless) blocks until all OutputDataReceived /
+        # ErrorDataReceived event handlers have finished processing — without
+        # this, CancelOutputRead() may discard data that hasn't been delivered
+        # yet, losing most of the captured output.
+        try { $proc.WaitForExit() } catch { }
+
         # Cancel the async readers, then drain synchronously to capture
         # everything that remains.
         try { $proc.CancelOutputRead() } catch { }
@@ -1828,6 +1843,22 @@ function Invoke-Agent {
     if ([string]::IsNullOrWhiteSpace($capturedOutput)) {
         Write-Host "  WARNING: No output captured from agent (file: $captureFile)" -ForegroundColor Yellow
         return
+    }
+
+    # ── Truncation detection ────────────────────────────────────────────────
+    # Detect when the capture file contains only a closing statement (e.g.
+    # "The full report with N issues is above") without the actual report
+    # content.  This indicates the async output capture lost most of the data.
+    $hasStructuredSections = $capturedOutput -match '(?i)(###?\s+[ABCD][.\s])'
+    $looksTruncated = (-not $hasStructuredSections) -and (
+        ($capturedOutput -match '(?i)is above\.?\s*$') -or
+        ($capturedOutput.Length -lt 500 -and $capturedOutput -match '(?i)(report|issues?|evaluation)\s+(is|are|complete)')
+    )
+    if ($looksTruncated) {
+        Write-Host "  WARNING: Captured output may be truncated — only $($capturedOutput.Length) chars, no structured sections found." -ForegroundColor Yellow
+        Write-Host "    The agent output was likely lost by the async capture mechanism." -ForegroundColor DarkGray
+        Write-Host "    Full raw output saved to: $captureFile" -ForegroundColor DarkGray
+        Write-Host "    Re-running the scenario may produce a complete capture." -ForegroundColor DarkGray
     }
 
     # Write to the issues ready queue

--- a/browser4-tests/real-world-scenarios/scripts/common.tests.ps1
+++ b/browser4-tests/real-world-scenarios/scripts/common.tests.ps1
@@ -1283,6 +1283,220 @@ Write-Host '━━━ Timeout Conversion Logic ━━━' -ForegroundColor Yello
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Test group 21: NativeCommandOutputHandler — C# class compiles and handles errors
+# ═══════════════════════════════════════════════════════════════════════════════
+
+Write-Host ''
+Write-Host '━━━ NativeCommandOutputHandler: Error Resilience ━━━' -ForegroundColor Yellow
+
+& {
+    $browser4cliMode = 'dev'
+    . "$PSScriptRoot/common.ps1"
+
+    # DataReceivedEventArgs has an internal constructor — use reflection.
+    $ctorInfo = [System.Diagnostics.DataReceivedEventArgs].GetConstructor(
+        [System.Reflection.BindingFlags]'NonPublic,Public,Instance',
+        $null, [Type[]]@([string]), $null)
+
+    Write-TestGroup 'C# handler type is compiled and loadable'
+    $handlerType = [NativeCommandOutputHandler]
+    Assert-True 'NativeCommandOutputHandler type exists' ($null -ne $handlerType)
+
+    Write-TestGroup 'Handler can be instantiated with a valid path'
+    $tempFile = [System.IO.Path]::GetTempFileName()
+    try {
+        $handler = New-Object NativeCommandOutputHandler $tempFile
+        Assert-True 'Handler instance created' ($null -ne $handler)
+    } finally {
+        Remove-Item $tempFile -ErrorAction SilentlyContinue
+    }
+
+    Write-TestGroup 'Handler writes data to capture file correctly'
+    $tempFile = [System.IO.Path]::GetTempFileName()
+    try {
+        $handler = New-Object NativeCommandOutputHandler $tempFile
+        $testLine = 'Test output line'
+        $eventArgs = $ctorInfo.Invoke(@($testLine))
+        $handler.OnOutputReceived($null, $eventArgs)
+
+        $content = [System.IO.File]::ReadAllText($tempFile, [System.Text.UTF8Encoding]::new($false))
+        Assert-True 'Capture file contains test line' $content.Contains($testLine)
+    } finally {
+        Remove-Item $tempFile -ErrorAction SilentlyContinue
+    }
+
+    Write-TestGroup 'Handler survives write to invalid path (try-catch prevents crash)'
+    $invalidPath = 'Z:\nonexistent\path\file.txt'
+    $handler = New-Object NativeCommandOutputHandler $invalidPath
+    $testLine = 'This write should fail gracefully'
+    $eventArgs = $ctorInfo.Invoke(@($testLine))
+    $threw = $false
+    try {
+        $handler.OnOutputReceived($null, $eventArgs)
+    } catch {
+        $threw = $true
+    }
+    Assert-True 'Handler does not throw on write failure (try-catch works)' (-not $threw)
+
+    Write-TestGroup 'Multiple writes accumulate in capture file'
+    $tempFile = [System.IO.Path]::GetTempFileName()
+    try {
+        $handler = New-Object NativeCommandOutputHandler $tempFile
+        $handler.OnOutputReceived($null, ($ctorInfo.Invoke(@('Line A'))))
+        $handler.OnOutputReceived($null, ($ctorInfo.Invoke(@('Line B'))))
+        $handler.OnOutputReceived($null, ($ctorInfo.Invoke(@('Line C'))))
+        $content = [System.IO.File]::ReadAllText($tempFile, [System.Text.UTF8Encoding]::new($false))
+        Assert-True 'All three lines captured' ($content.Contains('Line A') -and $content.Contains('Line B') -and $content.Contains('Line C'))
+    } finally {
+        Remove-Item $tempFile -ErrorAction SilentlyContinue
+    }
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test group 22: Start-NativeCommand — WaitForExit fix present
+# ═══════════════════════════════════════════════════════════════════════════════
+
+Write-Host ''
+Write-Host '━━━ Start-NativeCommand: WaitForExit Fix ━━━' -ForegroundColor Yellow
+
+& {
+    $browser4cliMode = 'dev'
+    . "$PSScriptRoot/common.ps1"
+
+    Write-TestGroup 'Start-NativeCommand function exists'
+    Assert-True 'Function is defined' ($null -ne (Get-Command Start-NativeCommand -ErrorAction SilentlyContinue))
+
+    # Static analysis: verify the parameterless WaitForExit() call exists
+    # after the heartbeat loop and before CancelOutputRead()
+    $commonPath = Join-Path $PSScriptRoot 'common.ps1'
+    $commonContent = Get-Content -LiteralPath $commonPath -Raw -Encoding UTF8
+
+    Write-TestGroup 'Parameterless WaitForExit() is called before CancelOutputRead'
+    # Extract the drain section between the heartbeat loop and the timeout check
+    $drainSection = ''
+    if ($commonContent -match '(?s)# ── Drain final output.+?# ── Timeout:') {
+        $drainSection = $Matches[0]
+    }
+    $hasWaitForExit = $drainSection -match '\$proc\.WaitForExit\(\)'
+    Assert-True 'WaitForExit() (parameterless) is called in drain section' $hasWaitForExit
+
+    Write-TestGroup 'WaitForExit() is called BEFORE CancelOutputRead (code calls)'
+    # Use $proc. prefix to avoid matching comment text like
+    # "CancelOutputRead() may discard data that hasn't been delivered"
+    $waitPos = $drainSection.IndexOf('$proc.WaitForExit()')
+    $cancelPos = $drainSection.IndexOf('$proc.CancelOutputRead()')
+    Assert-True 'WaitForExit() appears before CancelOutputRead()' ($waitPos -ge 0 -and $cancelPos -ge 0 -and $waitPos -lt $cancelPos)
+
+    Write-TestGroup 'WaitForExit() is wrapped in try-catch'
+    $hasTryCatch = $drainSection -match '(?s)try\s*\{\s*\$proc\.WaitForExit\(\)'
+    Assert-True 'WaitForExit() is wrapped in try-catch' $hasTryCatch
+
+    Write-TestGroup 'Heartbeat loop polls HasExited before the drain section'
+    $hasHeartbeatLoop = $commonContent -match 'while\s*\(-not\s*\$proc\.HasExited\)'
+    Assert-True 'Heartbeat loop exists (polls HasExited)' $hasHeartbeatLoop
+
+    Write-TestGroup 'C# handler has try-catch for File.AppendAllText'
+    Assert-True 'Handler has try-catch' ($commonContent -match '(?s)try\s*\{.*File\.AppendAllText')
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test group 23: Truncation detection — simulated content validation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+Write-Host ''
+Write-Host '━━━ Truncation Detection ━━━' -ForegroundColor Yellow
+
+& {
+    $browser4cliMode = 'dev'
+    . "$PSScriptRoot/common.ps1"
+
+    Write-TestGroup 'Full output with all sections is NOT flagged as truncated'
+    $fullOutput = @'
+### A. Task Result
+Task completed successfully.
+
+### B. Execution Trace
+Used commands: open, goto, tab-list.
+
+### C. Issues Found
+
+### Issue 1: Test issue
+**Severity:** Medium
+**Category:** UX
+
+### D. Overall Assessment
+All good, rating 8/10.
+'@
+    $hasSections = $fullOutput -match '(?i)(###?\s+[ABCD][.\s])'
+    Assert-True 'Full output has structured sections' $hasSections
+
+    $looksTruncated = (-not $hasSections) -and (
+        ($fullOutput -match '(?i)is above\.?\s*$') -or
+        ($fullOutput.Length -lt 500 -and $fullOutput -match '(?i)(report|issues?|evaluation)\s+(is|are|complete)')
+    )
+    Assert-True 'Full output is NOT flagged truncated' (-not $looksTruncated)
+
+    Write-TestGroup 'Closing-only output ("is above") IS flagged as truncated'
+    $closingOnly = 'The evaluation is complete. All testing has been performed, and the full report with 10 documented issues is above.'
+    $hasSections2 = $closingOnly -match '(?i)(###?\s+[ABCD][.\s])'
+    $looksTruncated2 = (-not $hasSections2) -and (
+        ($closingOnly -match '(?i)is above\.?\s*$') -or
+        ($closingOnly.Length -lt 500 -and $closingOnly -match '(?i)(report|issues?|evaluation)\s+(is|are|complete)')
+    )
+    Assert-True 'Closing-only output IS flagged truncated' $looksTruncated2
+
+    Write-TestGroup 'Short completion message ("report is complete") IS flagged'
+    $shortComplete = 'The full report is complete.'
+    $hasSections3 = $shortComplete -match '(?i)(###?\s+[ABCD][.\s])'
+    $looksTruncated3 = (-not $hasSections3) -and (
+        ($shortComplete -match '(?i)is above\.?\s*$') -or
+        ($shortComplete.Length -lt 500 -and $shortComplete -match '(?i)(report|issues?|evaluation)\s+(is|are|complete)')
+    )
+    Assert-True 'Short completion message IS flagged truncated' $looksTruncated3
+
+    Write-TestGroup 'Long output without sections but without closing markers is NOT flagged'
+    $longRandom = ('Random agent output without structured sections. ' * 30).Trim()
+    $hasSections4 = $longRandom -match '(?i)(###?\s+[ABCD][.\s])'
+    $looksTruncated4 = (-not $hasSections4) -and (
+        ($longRandom -match '(?i)is above\.?\s*$') -or
+        ($longRandom.Length -lt 500 -and $longRandom -match '(?i)(report|issues?|evaluation)\s+(is|are|complete)')
+    )
+    Assert-True 'Long random output NOT flagged truncated' (-not $looksTruncated4)
+
+    Write-TestGroup 'Output with ### C. Issues Found section is NOT flagged'
+    $hasCIssue = @'
+Some preamble text.
+
+### C. Issues Found
+
+### Issue 1: Something broken
+**Severity:** High
+**Category:** Product
+'@
+    $hasSections5 = $hasCIssue -match '(?i)(###?\s+[ABCD][.\s])'
+    $looksTruncated5 = (-not $hasSections5) -and (
+        ($hasCIssue -match '(?i)is above\.?\s*$') -or
+        ($hasCIssue.Length -lt 500 -and $hasCIssue -match '(?i)(report|issues?|evaluation)\s+(is|are|complete)')
+    )
+    Assert-True 'Output with C section NOT flagged truncated' (-not $looksTruncated5)
+
+    Write-TestGroup 'Truncation pattern detects "is above" at end of line'
+    $endOfLine = "The report is above.`n"
+    $aboveMatch = $endOfLine -match '(?i)is above\.?\s*$'
+    Assert-True 'Matches "is above." at end' $aboveMatch
+
+    Write-TestGroup 'Truncation pattern does NOT match "above" mid-sentence'
+    $midSentence = 'The above report contains 10 issues.'
+    $aboveMatch2 = $midSentence -match '(?i)is above\.?\s*$'
+    Assert-True 'Does NOT match "above" mid-sentence' (-not $aboveMatch2)
+
+    Write-TestGroup 'Truncation detection variable exists in common.ps1'
+    $commonPath = Join-Path $PSScriptRoot 'common.ps1'
+    $commonContent = Get-Content -LiteralPath $commonPath -Raw -Encoding UTF8
+    Assert-True 'looksTruncated variable exists' ($commonContent -match 'looksTruncated')
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Summary
 # ═══════════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Problem

The agent output capture in `Start-NativeCommand` was unreliable — ~75% of scenario runs produced `.full.md` files containing only the agent's closing line (e.g. "The evaluation is complete with 10 documented issues is above") instead of the full structured report with Sections A-D. This caused `ConvertFrom-IssuesSection` to parse zero issues.

### Root Cause

`WaitForExit(timeout)` can return before async `OutputDataReceived`/`ErrorDataReceived` event handlers have finished processing. The subsequent `CancelOutputRead()` call then discards in-flight data. Per [MSDN](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit):

> "When standard output has been redirected to asynchronous event handlers, it is possible that output processing will not have completed when this method returns. To ensure that asynchronous event handling has been completed, call the WaitForExit() overload that takes no parameter."

## Changes

### 1. Add parameterless `WaitForExit()` before `CancelOutputRead()` (`common.ps1`)
Ensures all async event handlers finish before the synchronous drain, preventing data loss.

### 2. Add try-catch to `NativeCommandOutputHandler` C# class
Exceptions in .NET threadpool event handlers are silently swallowed. Logging to stderr makes failures visible.

### 3. Add truncation detection in `Invoke-Agent`
After reading captured output, checks for the common failure pattern (closing statement only, no structured sections) and warns the user.

### 4. New tests (groups 21-23 in `common.tests.ps1`)
- **Group 21**: C# handler error resilience — valid writes, invalid paths, multi-line accumulation
- **Group 22**: Static analysis — verifies `WaitForExit()` is called before `CancelOutputRead()` in the drain section
- **Group 23**: Truncation detection logic — validates the detection patterns with 8 sub-tests

## Verification

All 18 manual verification tests pass, covering:
- Handler instantiation and write functionality
- Handler survives write-to-invalid-path (try-catch works)
- Truncation detection correctly flags/doesn't flag various output patterns
- Static analysis confirms code structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)