### PR TITLE
fix(build): fix PS 5.1 compatibility and missing coroutines import

### DIFF
--- a/bin/build/build.ps1
+++ b/bin/build/build.ps1
@@ -9,6 +9,10 @@
 
 $ErrorActionPreference = "Stop"
 
+# PS 5.1 compatibility: $IsWindows/$IsLinux/$IsMacOS were introduced in PS 6.
+# On PS 5.1 (Windows-only), all three are $null, so we fall back to env:OS.
+$IsWin = ($IsWindows -or $env:OS -eq 'Windows_NT')
+
 $repoRoot = (git rev-parse --show-toplevel 2>$null)
 if (-not $repoRoot) {
   Write-Host "Error: not in a git repository" -ForegroundColor Red
@@ -17,8 +21,8 @@ if (-not $repoRoot) {
 Set-Location $repoRoot
 
 # Resolve the Maven wrapper for this platform
-$MvnwScript = if ($IsWindows) { Join-Path $repoRoot 'mvnw.cmd' }
-              else              { Join-Path $repoRoot 'mvnw'     }
+$MvnwScript = if ($IsWin) { Join-Path $repoRoot 'mvnw.cmd' }
+              else        { Join-Path $repoRoot 'mvnw'     }
 
 # ═══════════════════════════════════════════════════════
 # Build-state tracking files (used by --resume and AI diagnosis)
@@ -59,7 +63,7 @@ function Write-SystemInfo {
   [void]$lines.Add("")
 
   # --- OS ---
-  if ($IsWindows) {
+  if ($IsWin) {
     $osName = "Windows"
     $osVer = [Environment]::OSVersion.VersionString
   }
@@ -79,7 +83,7 @@ function Write-SystemInfo {
 
   # --- CPU ---
   try {
-    if ($IsWindows) {
+    if ($IsWin) {
       $cpuName = ((Get-CimInstance Win32_Processor -ErrorAction Stop).Name -split '\s+')[0..6] -join ' '
       $cpuCores = (Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).NumberOfLogicalProcessors
     }
@@ -100,7 +104,7 @@ function Write-SystemInfo {
 
   # --- Memory ---
   try {
-    if ($IsWindows) {
+    if ($IsWin) {
       $totalMemGB = [math]::Round((Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).TotalPhysicalMemory / 1GB, 1)
     }
     elseif ($IsLinux) {

--- a/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/tools/experience/KnowledgeStorePersistenceFailureTest.kt
+++ b/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/tools/experience/KnowledgeStorePersistenceFailureTest.kt
@@ -1,5 +1,6 @@
 package ai.platon.pulsar.agentic.tools.experience
 
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -8,7 +9,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.attribute.PosixFilePermissions
 import java.time.Instant
 import kotlin.io.path.*
 import kotlin.test.*


### PR DESCRIPTION
## Summary
Two build fixes from running `.\b4w.ps1 build -main` on Windows PS 5.1:

### 1. PS 5.1 compatibility in `bin/build/build.ps1`
`$IsWindows` / `$IsLinux` / `$IsMacOS` variables were introduced in PowerShell 6. On PS 5.1, all three are `$null`, causing wrong mvnw selection and failed OS/CPU/Memory detection.

### 2. Missing `runBlocking` import in `KnowledgeStorePersistenceFailureTest.kt`
Added `import kotlinx.coroutines.runBlocking` and removed unused `PosixFilePermissions`.

## Verification
Full build passes: all 27 modules BUILD SUCCESS.
