### PR TITLE
fix(test): restore Maven output visibility when running `b4w.ps1 test main`

### DIFF
--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -110,7 +110,7 @@ function Invoke-CommandAndReport {
         if ($PreExecPath) { Push-Location $PreExecPath }
         $global:LASTEXITCODE = 0
         if ($NoExit) {
-            $null = & $ScriptBlock
+            & $ScriptBlock *>&1 | Out-Host
         } else {
             & $ScriptBlock
         }


### PR DESCRIPTION
## Problem

When running `b4w.ps1 test main`, the Maven test output was invisible — only stderr messages (JAVA_TOOL_OPTIONS) appeared. The actual test compilation and results were silently discarded.

## Root cause

`Invoke-CommandAndReport` with `-NoExit` used `$null = & $ScriptBlock` which captures all stdout and sends it to the void. The caller `Invoke-MavenTests` uses `-NoExit` so it can persist the test session result after checking the exit code.

## Fix

Replace `$null = & $ScriptBlock` with `& $ScriptBlock *>&1 | Out-Host` — streams all output (stdout + stderr) to the console via `Out-Host` without polluting the function's return value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution feedback by displaying combined command output when configured to return an exit code instead of exiting on failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->