### PR TITLE
feat(htmlsnapshot): add --clean flag to export command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,20 @@ File-queue system for task-driven AI workflows (`coworker/`). Task files (Markdo
 | Port 8182 in use | Override `server.port` in root `application.properties` |
 | BrowserProtocol retry log storms | Use existing retry utilities, lower log level |
 
+## Documentation Update Rule
+
+When a user says **"update documents"** (or "update docs", "refresh documentation"), update ALL of the following that reference the changed feature:
+
+1. **`README.md`** and **`README.zh.md`** — root-level project readmes
+2. **`skills/browser4-cli/SKILL.md`** — primary CLI skill document
+3. **`skills/browser4-cli/references/*.md`** — reference docs (htmlsnapshot.md, x-sql.md, etc.)
+4. **`cli/browser4-cli/README.md`** — CLI-specific README
+5. **`cli/browser4-cli/src/help.rs`** — CLI help text generation
+6. **`cli/browser4-cli/src/tips.rs`** — CLI tips/hints shown to users
+7. **Any other `.md` files** in `docs/`, `skills/`, or project root that reference the changed command or feature
+
+When adding a new CLI option or changing command behavior, always check these locations.
+
 ## Documentation References
 
 - [Testing Taxonomy](docs/TESTING.md)

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ htmlsnapshot capture                        Capture a static HTML snapshot and s
 htmlsnapshot                                Short form of `htmlsnapshot capture`
 htmlsnapshot get <field> [selector] [name]  Extract text, html, or attr from the stored HTML snapshot
 htmlsnapshot query [url]                    Run X-SQL against the stored HTML snapshot (--sql <query|@file>)
-htmlsnapshot export                         Export snapshot HTML to a local file (--file <path>)
+htmlsnapshot export                         Export snapshot HTML to a local file (--file <path>, --clean)
 htmlsnapshot summary                        Generate a compressed Web Page Summary Index (WPSI)
 htmlsnapshot grep <pattern>                 Search snapshot HTML with regex
                                            -i, -v, -c, -l, -F, -w, -A, -B, -C, --selector
@@ -401,6 +401,7 @@ browser4-cli htmlsnapshot capture
 browser4-cli htmlsnapshot
 browser4-cli htmlsnapshot get text "#main-content"
 browser4-cli htmlsnapshot query --sql @query.sql
+browser4-cli htmlsnapshot export --file page.html --clean
 browser4-cli htmlsnapshot grep -i "error"
 
 # AI-powered extraction and summarization (requires LLM key — see LLM Configuration above)

--- a/README.zh.md
+++ b/README.zh.md
@@ -191,7 +191,7 @@ htmlsnapshot capture                        捕获静态 DOM 快照并将其存�
 htmlsnapshot                                `htmlsnapshot capture` 的简写形式
 htmlsnapshot get <field> [selector] [name]  从存储的 DOM 快照中提取 text、html 或 attr
 htmlsnapshot query [url]                    对存储的 DOM 快照运行 X-SQL (--sql <query|@file>)
-htmlsnapshot export                         将快照 HTML 导出到本地文件 (--file <path>)
+htmlsnapshot export                         将快照 HTML 导出到本地文件 (--file <path>, --clean)
 htmlsnapshot summary                        生成压缩的网页摘要索引 (WPSI)
 htmlsnapshot grep <pattern>                 使用正则表达式搜索快照 HTML
                                            -i, -v, -c, -l, -F, -w, -A, -B, -C, --selector
@@ -404,6 +404,7 @@ browser4-cli htmlsnapshot capture
 browser4-cli htmlsnapshot
 browser4-cli htmlsnapshot get text "#main-content"
 browser4-cli htmlsnapshot query --sql @query.sql
+browser4-cli htmlsnapshot export --file page.html --clean
 browser4-cli htmlsnapshot grep -i "error"
 
 # AI 驱动的提取与总结（需要 LLM 密钥 — 参见上方的 LLM 配置）

--- a/browser4-rest/src/main/kotlin/ai/platon/pulsar/agent/tool/HTMLSnapshotToolExecutor.kt
+++ b/browser4-rest/src/main/kotlin/ai/platon/pulsar/agent/tool/HTMLSnapshotToolExecutor.kt
@@ -91,9 +91,10 @@ class HTMLSnapshotToolExecutor(
             method = "export",
             arguments = listOf(
                 ToolSpec.Arg("sessionId", "String", null),
+                ToolSpec.Arg("clean", "Boolean", "false"),
             ),
             returnType = "String",
-            description = "Export the full, pretty-printed HTML of the current page."
+            description = "Export the full, pretty-printed HTML of the current page. Set clean=true to strip <script>, <style>, and non-standard attributes (keeps the vi attribute)."
         )
 
         toolSpec["summary"] = ToolSpec(
@@ -316,6 +317,7 @@ class HTMLSnapshotToolExecutor(
 
     private suspend fun export(args: Map<String, Any?>): String {
         val sessionId = requireSessionId(args)
+        val clean = paramBool(args, "clean", "export", required = false, default = false) ?: false
         val managed = sessionManager.getSession(sessionId)
             ?: throw IllegalArgumentException("Session not found: $sessionId")
 
@@ -324,8 +326,76 @@ class HTMLSnapshotToolExecutor(
             val url = pulsarSession.normalize(driver.currentUrl())
             val page = pulsarSession.getOrNull(url.urlString) ?: pulsarSession.capture(managed.driver)
             val document = pulsarSession.parse(page)
+
+            if (clean) {
+                cleanDocument(document)
+            }
+
             document.outerHtml
         }
+    }
+
+    /**
+     * Strip scripts, styles, and non-standard attributes from HTML.
+     *
+     * Removes:
+     * - `<script>` and `<style>` elements (including their content)
+     * - `<noscript>` elements
+     * - HTML comments (within elements)
+     * - Non-standard attributes on all elements (keeps `vi`, standard HTML5 attrs,
+     *   `aria-*`, `role`, `data-*`, and microdata `item*` attrs)
+     */
+    private fun cleanDocument(document: ai.platon.pulsar.dom.FeaturedDocument) {
+        document.select("script, style, noscript").remove()
+
+        for (el in document.select("*")) {
+            val comments = el.childNodes().filterIsInstance<org.jsoup.nodes.Comment>()
+            for (c in comments) {
+                c.remove()
+            }
+
+            val attrsToRemove = el.attributes().asList()
+                .map { it.key }
+                .filter { key -> !STANDARD_HTML_ATTRIBUTES.contains(key) && !isStandardAttributePrefix(key) }
+                .toList()
+            for (key in attrsToRemove) {
+                el.removeAttr(key)
+            }
+        }
+    }
+
+    private fun isStandardAttributePrefix(name: String): Boolean {
+        return name.startsWith("aria-") ||
+            name.startsWith("data-") ||
+            (name.startsWith("item") && (name == "itemscope" || name == "itemtype" ||
+                name == "itemprop" || name == "itemid" || name == "itemref"))
+    }
+
+    companion object {
+        private val STANDARD_HTML_ATTRIBUTES: Set<String> = setOf(
+            "accesskey", "autocapitalize", "autofocus", "class", "contenteditable",
+            "dir", "draggable", "enterkeyhint", "hidden", "id", "inert", "inputmode",
+            "is", "lang", "nonce", "popover", "slot", "spellcheck", "style",
+            "tabindex", "title", "translate", "writingsuggestions",
+            "accept", "action", "align", "alt", "async", "autocomplete",
+            "autoplay", "charset", "checked", "cite", "cols", "colspan",
+            "content", "controls", "coords", "crossorigin", "datetime", "decoding",
+            "default", "defer", "dirname", "disabled", "download",
+            "enctype", "for", "form", "formaction", "formenctype", "formmethod",
+            "formnovalidate", "formtarget", "headers", "height", "high", "href",
+            "hreflang", "http-equiv", "integrity", "kind", "label", "list",
+            "loading", "loop", "low", "max", "maxlength", "media", "method",
+            "min", "minlength", "multiple", "muted", "name", "nomodule",
+            "novalidate", "open", "optimum", "pattern", "ping", "placeholder",
+            "playsinline", "popovertarget", "popovertargetaction", "poster",
+            "preload", "readonly", "referrerpolicy", "rel", "required",
+            "reversed", "rows", "rowspan", "sandbox", "scope", "selected",
+            "shape", "size", "sizes", "span", "src", "srcdoc", "srclang",
+            "srcset", "start", "step", "target", "type", "usemap", "value",
+            "width", "wrap",
+            "role",
+            "vi",
+        )
     }
 
     private suspend fun summary(args: Map<String, Any?>): String {

--- a/cli/README.md
+++ b/cli/README.md
@@ -496,7 +496,7 @@ browser4-cli htmlsnapshot
 browser4-cli htmlsnapshot get <field> [selector] [name]
 browser4-cli htmlsnapshot get all <field> [selector] [name]
 browser4-cli htmlsnapshot query [url] --sql <query>
-browser4-cli htmlsnapshot export [--file <path>]
+browser4-cli htmlsnapshot export [--file <path>] [--clean]
 browser4-cli htmlsnapshot summary
 browser4-cli htmlsnapshot grep [OPTIONS] <pattern>
 browser4-cli htmlsnapshot inspect [selector] [--max N] [--depth D]
@@ -588,10 +588,11 @@ browser4-cli htmlsnapshot query --sql "
 
 #### htmlsnapshot export
 
-Save the full snapshot HTML to a local file.
+Save the full snapshot HTML to a local file. Use `--clean` to strip `<script>`, `<style>`, comments, and non-standard attributes — producing minimal HTML ideal for LLM consumption.
 
 ```bash
 browser4-cli htmlsnapshot export --file snapshot.html
+browser4-cli htmlsnapshot export --file page.html --clean
 ```
 
 #### htmlsnapshot summary

--- a/cli/browser4-cli/README.md
+++ b/cli/browser4-cli/README.md
@@ -151,7 +151,7 @@ The backend server starts automatically in dev mode. Build the CLI with `cargo b
 | `htmlsnapshot capture` | Capture a static HTML snapshot and return metadata |
 | `htmlsnapshot get <field> [selector] [name]` | Extract elements from the stored HTML snapshot (text, html, attr) |
 | `htmlsnapshot query [url]` | Run X-SQL against the stored HTML snapshot |
-| `htmlsnapshot export` | Export snapshot HTML to a local file |
+| `htmlsnapshot export` | Export snapshot HTML to a local file (--clean strips scripts/styles/non-standard attrs) |
 | `htmlsnapshot summary` | Generate a compressed Web Page Summary Index (WPSI) from the stored HTML snapshot |
 | `htmlsnapshot grep [OPTIONS] <pattern>` | Search snapshot HTML with regex patterns and grep-style output |
 | `generate-locator <ref>` | Generate a unique CSS selector path for an element |

--- a/cli/browser4-cli/src/commands.rs
+++ b/cli/browser4-cli/src/commands.rs
@@ -2919,12 +2919,19 @@ pub fn all_commands() -> Vec<CommandDef> {
                     is_bool: false,
                     short: None,
                 },
+                OptionDef {
+                    name: "clean",
+                    description: "Strip <script>, <style>, comments, and non-standard attributes (keeps 'vi', aria-*, data-*, role, and standard HTML5 attrs)",
+                    is_bool: true,
+                    short: None,
+                },
             ],
             e2e_coverage: E2eCoverage::Tested,
             tool_name_fn: |_| "html_snapshot_export".to_string(),
             tool_params_fn: |args| {
                 let mut p = json!({});
                 if let Some(f) = get_opt_str(args, "file") { p["file"] = json!(f); }
+                if let Some(true) = get_bool(args, "clean") { p["clean"] = json!(true); }
                 p
             },
         },
@@ -4931,6 +4938,19 @@ mod tests {
         args.insert("file".to_string(), json!("snapshot.html"));
         let params = (cmd.tool_params_fn)(&args);
         assert_eq!(params["file"], "snapshot.html");
+        assert!(params.get("clean").is_none());
+    }
+
+    #[test]
+    fn test_html_snapshot_export_clean_params() {
+        let map = commands_map();
+        let cmd = map.get("htmlsnapshot-export").unwrap();
+        let mut args = HashMap::new();
+        args.insert("file".to_string(), json!("snapshot.html"));
+        args.insert("clean".to_string(), json!(true));
+        let params = (cmd.tool_params_fn)(&args);
+        assert_eq!(params["file"], "snapshot.html");
+        assert_eq!(params["clean"], true);
     }
 
     #[test]

--- a/cli/browser4-cli/src/help.rs
+++ b/cli/browser4-cli/src/help.rs
@@ -1168,7 +1168,7 @@ pub fn generate_command_help(cmd: &CommandDef) -> String {
             4,
         ));
         lines.push(
-            "  - Export the full HTML snapshot from Browser4's page storage to a local file with `htmlsnapshot export --file <path>`."
+            "  - Export the full HTML snapshot from Browser4's page storage to a local file with `htmlsnapshot export --file <path>`. Add `--clean` to strip scripts, styles, and non-standard attributes."
                 .to_string(),
         );
         lines.push(wrap_text(
@@ -1246,8 +1246,9 @@ pub fn generate_command_help(cmd: &CommandDef) -> String {
         lines.push("  # Return only the resultSet array, omitting wrapper metadata".to_string());
         lines.push("  browser4-cli htmlsnapshot query --sql @query.sql --result-only".to_string());
         lines.push(String::new());
-        lines.push("  # Export the full snapshot HTML to a file".to_string());
+        lines.push("  # Export the full snapshot HTML to a file (add --clean for LLM consumption)".to_string());
         lines.push("  browser4-cli htmlsnapshot export --file snapshot.html".to_string());
+        lines.push("  browser4-cli htmlsnapshot export --file clean.html --clean".to_string());
         lines.push(String::new());
         lines.push("  # Generate a compressed page summary from the stored HTML snapshot".to_string());
         lines.push("  browser4-cli htmlsnapshot summary".to_string());
@@ -2289,6 +2290,7 @@ mod tests {
         assert!(help.contains("browser4-cli htmlsnapshot query --sql-base64"));
         assert!(help.contains("browser4-cli htmlsnapshot query --sql @query.sql --result-only"));
         assert!(help.contains("browser4-cli htmlsnapshot export --file snapshot.html"));
+        assert!(help.contains("browser4-cli htmlsnapshot export --file clean.html --clean"));
         assert!(help.contains("browser4-cli htmlsnapshot summary"));
         // grep and inspect
         assert!(help.contains("htmlsnapshot grep [OPTIONS] <pattern>"));
@@ -2362,6 +2364,7 @@ mod tests {
         assert!(help.contains("browser4-cli htmlsnapshot export"));
         assert!(help.contains("Export snapshot HTML from Browser4's page storage to a local file"));
         assert!(help.contains("--file"));
+        assert!(help.contains("--clean"));
         assert!(!help.contains("browser4-cli htmlsnapshot-export"));
     }
 

--- a/cli/browser4-cli/src/tips.rs
+++ b/cli/browser4-cli/src/tips.rs
@@ -62,6 +62,9 @@ const TIPS_HTMLSNAPSHOT_GET: &[Tip] = &[
     Tip {
         text: "Use `--page N --page-size 500` for paginated results when extracting many elements",
     },
+    Tip {
+        text: "Use `htmlsnapshot export --clean` to strip scripts, styles, and non-standard attributes — produces minimal HTML ideal for LLM consumption",
+    },
 ];
 
 const TIPS_HTMLSNAPSHOT_QUERY: &[Tip] = &[
@@ -362,7 +365,7 @@ thread_local! {
 fn tips_for_command(command: &str) -> &'static [Tip] {
     match command {
         "snapshot" | "snapshot-grep" => TIPS_SNAPSHOT,
-        "htmlsnapshot" => TIPS_HTMLSNAPSHOT_GET,
+        "htmlsnapshot" | "htmlsnapshot-export" => TIPS_HTMLSNAPSHOT_GET,
         "htmlsnapshot-get" => TIPS_HTMLSNAPSHOT_GET,
         "htmlsnapshot-query" => TIPS_HTMLSNAPSHOT_QUERY,
         "htmlsnapshot-grep" => TIPS_HTMLSNAPSHOT_GREP,
@@ -492,6 +495,7 @@ mod tests {
         assert!(!tips_for_command("htmlsnapshot-get").is_empty());
         assert!(!tips_for_command("htmlsnapshot-query").is_empty());
         assert!(!tips_for_command("htmlsnapshot-grep").is_empty());
+        assert!(!tips_for_command("htmlsnapshot-export").is_empty());
         assert!(!tips_for_command("htmlsnapshot-inspect").is_empty());
         // Eval
         assert!(!tips_for_command("eval").is_empty());

--- a/skills/browser4-cli/references/htmlsnapshot.md
+++ b/skills/browser4-cli/references/htmlsnapshot.md
@@ -26,7 +26,7 @@ browser4-cli htmlsnapshot                                # capture fresh static 
 browser4-cli htmlsnapshot get <field> [selector] [name] [--page N] [--page-size N] [--all]  # extract text/html/attr via CSS; html paginated at 2K lines, text not paginated
 browser4-cli htmlsnapshot query [url] --sql <query>      # X-SQL query against DOM (url defaults to current page)
 browser4-cli htmlsnapshot summary                        # compressed page summary (WPSI)
-browser4-cli htmlsnapshot export [--file <path>]         # save snapshot HTML to file
+browser4-cli htmlsnapshot export [--file <path>] [--clean]  # save snapshot HTML to file
 browser4-cli htmlsnapshot get all <field> [selector] [name] [--offset N] [--limit N] [--page N] [--page-size N] [--all]  # extract ALL matches; html paginated at 2K lines, text not paginated
 browser4-cli htmlsnapshot grep [OPTIONS] <pattern> [--page N] [--page-size N] [--all]  # search snapshot HTML with regex; paginated by default (2K lines)
 browser4-cli htmlsnapshot inspect [selector] [--max N] [--depth D]  # analyze DOM structure, suggest CSS selectors
@@ -160,10 +160,10 @@ browser4-cli htmlsnapshot summary
 
 ## Export
 
-Save full snapshot HTML to a local file. The exported HTML is pretty-formatted for direct use with tools like `grep`.
+Save full snapshot HTML to a local file. The exported HTML is pretty-formatted for direct use with tools like `grep`. Use `--clean` to produce a minimal HTML file suitable for LLM consumption — strips `<script>`, `<style>`, `<noscript>`, comments, and non-standard attributes while preserving semantic structure.
 
 ```bash
-browser4-cli htmlsnapshot export [--file page-snapshot.html]
+browser4-cli htmlsnapshot export [--file page-snapshot.html] [--clean]
 ```
 
 ## Grep — Search snapshot HTML

--- a/skills/browser4-cli/references/webdb.md
+++ b/skills/browser4-cli/references/webdb.md
@@ -146,7 +146,7 @@ echo "Exported $succeeded pages ($failed failed)"
 | Command | Exports | Format | Requires cache? |
 |---------|---------|--------|-----------------|
 | `webdb-export` | Raw page HTML | `.htm` files | Yes (webdb) |
-| `htmlsnapshot export` | Structured DOM snapshot | JSON | No (works from current page) |
+| `htmlsnapshot export` | Formatted HTML DOM | HTML (use `--clean` for minimal LLM-ready output) | No (works from current page) |
 | `screenshot` | Visual page image | PNG | No (renders live) |
 | `pdf` | Print-formatted page | PDF | No (renders live) |
 | `crawl --sql --format csv -o out.csv` | Extracted data fields | CSV/JSON/table | Yes (uses webdb internally) |


### PR DESCRIPTION
## Summary

Adds a `--clean` flag to `htmlsnapshot export` that strips non-semantic content from the exported HTML, producing a minimal file suitable for LLM consumption and storage efficiency.

## What it strips

- **`<script>`** elements and their content
- **`<style>`** elements and their content
- **`<noscript>`** elements
- **HTML comments** (within elements)
- **Non-standard attributes** on all elements

## What it preserves

All standard HTML5 attributes are kept on a whitelist basis:
- HTML Living Standard global attributes (id, class, style, title, lang, etc.)
- Common element attributes (href, src, alt, type, name, value, placeholder, etc.)
- `role` attribute
- `aria-*` attributes (accessibility)
- `data-*` attributes (custom data)
- Microdata `item*` attributes (itemscope, itemtype, itemprop, itemid, itemref)
- **`vi`** — Browser4's viewport-info attribute (bounding boxes)

## Changes

| File | Change |
|---|---|
| `HTMLSnapshotToolExecutor.kt` | Added `clean` param to export tool spec + `cleanDocument()` JSoup method + attribute whitelist |
| `commands.rs` | Added `--clean` boolean option to `htmlsnapshot-export` command |
| `help.rs` | Updated generated help text, examples, and tests |
| `tips.rs` | Added tip about `--clean`, mapped `htmlsnapshot-export` to tips |
| `htmlsnapshot.md` | Updated docs |
| `README.md`, `README.zh.md` | Updated export descriptions and examples |
| `cli/README.md`, `cli/browser4-cli/README.md` | Updated export docs |
| `webdb.md` | Corrected format (HTML, not JSON), mentioned `--clean` |
| `AGENTS.md` | Added 'update documents' rule for future doc changes |

## Usage

```bash
# Normal export
browser4-cli htmlsnapshot export --file page.html

# Clean export for LLM consumption
browser4-cli htmlsnapshot export --file page.html --clean
```

## Testing

- Rust unit tests: 286/286 pass (commands + help + tips)
- Kotlin compilation: ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)