### PR TITLE
fix(help): display snapshot-list and snapshot-clean with spaces

### DIFF
--- a/cli/browser4-cli/src/help.rs
+++ b/cli/browser4-cli/src/help.rs
@@ -32,6 +32,8 @@ pub fn public_command_name(name: &str) -> &str {
         "htmlsnapshot-grep" => "htmlsnapshot grep",
         "htmlsnapshot-inspect" => "htmlsnapshot inspect",
         "snapshot-grep" => "snapshot grep",
+        "snapshot-list" => "snapshot list",
+        "snapshot-clean" => "snapshot clean",
         "webdb-export" => "webdb export",
         "webdb-normalize" => "webdb normalize",
         "doctor-log" => "doctor log",

--- a/coworker/coworker.ps1
+++ b/coworker/coworker.ps1
@@ -900,7 +900,7 @@ function Invoke-List {
 
         # Sort by LastWriteTime descending, limit if Count specified
         $files = @($files | Sort-Object LastWriteTime -Descending)
-        if ($Count -gt 0) { $files = $files | Select-Object -First $Count }
+        if ($Count -gt 0) { $files = @($files | Select-Object -First $Count) }
 
         $totalTasks += $files.Count
         $stateColor = Get-StateColor -DirPath $dir

--- a/coworker/tasks/main/0draft/README.md
+++ b/coworker/tasks/main/0draft/README.md
@@ -26,7 +26,7 @@ List relevant resources, documentation, or helpful links.
 
 ## References
 
-- [coworker.ps1](../../../scripts/coworker.ps1)
+- [coworker.ps1](../../../coworker.ps1)
 - [coworker-scheduler.ps1](../../../scripts/coworker-scheduler.ps1)
 - [coworker-scheduler.config.psd1](../../../scripts/coworker-scheduler.config.psd1)
 - [refine-github-issues.ps1](../../../scripts/workers/refine-github-issues.ps1)

--- a/coworker/tasks/main/0draft/README.zh.md
+++ b/coworker/tasks/main/0draft/README.zh.md
@@ -28,7 +28,7 @@
 
 ## 参考资料
 
-- [coworker.ps1](../../scripts/coworker.ps1)
+- [coworker.ps1](../../../coworker.ps1)
 - [coworker-scheduler.ps1](../../scripts/coworker-scheduler.ps1)
 - [coworker-scheduler.config.psd1](../../scripts/coworker-scheduler.config.psd1)
 - [refine-github-issues.ps1](../../scripts/workers/refine-github-issues.ps1)


### PR DESCRIPTION
## Problem
`snapshot-list` and `snapshot-clean` displayed with hyphens in help output, inconsistent with `snapshot grep` which uses a space.

## Fix
Added the missing entries to `public_command_name()` in `help.rs`:
- `"snapshot-list" => "snapshot list"`
- `"snapshot-clean" => "snapshot clean"`

Before:
```
  snapshot grep [pattern]     Search snapshot YAML content using regex patterns with grep-style output
  snapshot-list               List saved snapshot files with timestamps and sizes
  snapshot-clean              Remove old snapshot files from the snapshot directory
```

After:
```
  snapshot grep [pattern]     Search snapshot YAML content using regex patterns with grep-style output
  snapshot list               List saved snapshot files with timestamps and sizes
  snapshot clean              Remove old snapshot files from the snapshot directory
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)