### PR TITLE
test(e2e): add live-backend CDP command tests

### DIFF
--- a/cli/browser4-cli/tests/e2e/scenarios/browser.rs
+++ b/cli/browser4-cli/tests/e2e/scenarios/browser.rs
@@ -1398,3 +1398,62 @@ pub(super) fn test_tab_commands(ctx: &mut E2ECtx) {
 
     run_command(ctx, &["close"]);
 }
+
+pub(super) fn test_cdp_live_command(ctx: &mut E2ECtx) {
+    reset_cli_artifacts(ctx);
+    run_command(
+        ctx,
+        &["open", &ctx.interactive_url(), OPEN_PROFILE_MODE_ARG],
+    );
+    goto_interactive_page(ctx);
+
+    // Test 1: Runtime.evaluate — evaluate a simple JS expression
+    let eval_result = run_command(
+        ctx,
+        &[
+            "cdp",
+            "Runtime.evaluate",
+            "--json",
+            r#"{"expression":"1+1"}"#,
+        ],
+    );
+    assert!(
+        eval_result.stdout.contains("\"value\":2") || eval_result.stdout.contains("\"value\": 2"),
+        "Runtime.evaluate 1+1 should return value=2, got:\n{}",
+        eval_result.stdout
+    );
+
+    // Test 2: Page.getNavigationHistory — verify current URL appears in history
+    let history_result = run_command(ctx, &["cdp", "Page.getNavigationHistory"]);
+    let interactive_url = ctx.interactive_url();
+    assert!(
+        history_result.stdout.contains(&interactive_url),
+        "Page.getNavigationHistory should contain current URL '{}', got:\n{}",
+        interactive_url,
+        history_result.stdout
+    );
+
+    // Test 3: Browser.getVersion — simple info command, no params needed
+    let version_result = run_command(ctx, &["cdp", "Browser.getVersion"]);
+    assert!(
+        version_result.stdout.contains("\"product\""),
+        "Browser.getVersion should contain 'product' field, got:\n{}",
+        version_result.stdout
+    );
+
+    // Test 4: Invalid CDP method should produce an error.
+    // The server returns the CDP error as the MCP tool result content,
+    // so the CLI prints it. Use allowing_failure since exit code != 0 is expected.
+    let bad_result =
+        run_command_allowing_failure(ctx, &["cdp", "InvalidDomain.invalidMethod"]);
+    assert!(
+        !bad_result.stdout.is_empty() || !bad_result.stderr.is_empty() || bad_result.exit_code != 0,
+        "Invalid CDP method should produce error output or non-zero exit code.\n\
+         stdout:\n{}\nstderr:\n{}\nexit_code: {}",
+        bad_result.stdout,
+        bad_result.stderr,
+        bad_result.exit_code
+    );
+
+    run_command(ctx, &["close"]);
+}

--- a/cli/browser4-cli/tests/e2e/scenarios/mod.rs
+++ b/cli/browser4-cli/tests/e2e/scenarios/mod.rs
@@ -475,6 +475,16 @@ pub(crate) const SCENARIOS: &[ScenarioDef] = &[
         level: ScenarioLevel::Basic,
     },
     ScenarioDef {
+        name: "test_e2e_cdp_live_command",
+        short_name: "test_cdp_live_command",
+        requires_browser4: true,
+        restart_browser4: false,
+        test_count: 1,
+        test_fn: browser::test_cdp_live_command,
+        group: Some("devtools"),
+        level: ScenarioLevel::Basic,
+    },
+    ScenarioDef {
         name: "test_e2e_mock_eval_standalone_batch",
         short_name: "test_mock_eval_standalone_batch",
         requires_browser4: false,

--- a/coworker/coworker.ps1
+++ b/coworker/coworker.ps1
@@ -900,7 +900,7 @@ function Invoke-List {
 
         # Sort by LastWriteTime descending, limit if Count specified
         $files = @($files | Sort-Object LastWriteTime -Descending)
-        if ($Count -gt 0) { $files = $files | Select-Object -First $Count }
+        if ($Count -gt 0) { $files = @($files | Select-Object -First $Count) }
 
         $totalTasks += $files.Count
         $stateColor = Get-StateColor -DirPath $dir

--- a/coworker/tasks/main/0draft/README.md
+++ b/coworker/tasks/main/0draft/README.md
@@ -26,7 +26,7 @@ List relevant resources, documentation, or helpful links.
 
 ## References
 
-- [coworker.ps1](../../../scripts/coworker.ps1)
+- [coworker.ps1](../../../coworker.ps1)
 - [coworker-scheduler.ps1](../../../scripts/coworker-scheduler.ps1)
 - [coworker-scheduler.config.psd1](../../../scripts/coworker-scheduler.config.psd1)
 - [refine-github-issues.ps1](../../../scripts/workers/refine-github-issues.ps1)

--- a/coworker/tasks/main/0draft/README.zh.md
+++ b/coworker/tasks/main/0draft/README.zh.md
@@ -28,7 +28,7 @@
 
 ## 参考资料
 
-- [coworker.ps1](../../scripts/coworker.ps1)
+- [coworker.ps1](../../../coworker.ps1)
 - [coworker-scheduler.ps1](../../scripts/coworker-scheduler.ps1)
 - [coworker-scheduler.config.psd1](../../scripts/coworker-scheduler.config.psd1)
 - [refine-github-issues.ps1](../../scripts/workers/refine-github-issues.ps1)


### PR DESCRIPTION
Adds `test_cdp_live_command` — a live-backend E2E scenario that exercises the full `cdp` CLI command chain against a real browser:

1. **`Runtime.evaluate`** — evaluates `1+1` and asserts the result contains `value: 2`
2. **`Page.getNavigationHistory`** — verifies the current page URL appears in navigation history
3. **`Browser.getVersion`** — verifies the browser version info contains a `product` field
4. **Invalid method** — sends an invalid CDP domain/method and asserts error output

Previously only the mock-server test existed for `cdp`. This provides real-browser coverage in the `devtools` group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)