### PR TITLE
fix(test): make PromptsTest.request lazy to avoid init-time mock port resolution

### DIFF
--- a/browser4-tests/browser4-rest-tests/src/test/kotlin/ai/platon/pulsar/rest/api/common/PromptsTest.kt
+++ b/browser4-tests/browser4-rest-tests/src/test/kotlin/ai/platon/pulsar/rest/api/common/PromptsTest.kt
@@ -19,22 +19,25 @@ const val PLACEHOLDER_PAGE_CONTENT = "page_content"
 @ContextConfiguration(initializers = [PulsarTestContextInitializer::class])
 @Import(MockEcServerConfiguration::class)
 class PromptsTest : MockEcServerTestBase() {
-    private val request = CommandRequest(
-        url = MOCK_PRODUCT_DETAIL_URL,
-        onBrowserLaunchedActions = listOf(
-            "clear browser cookies",
-            "goto the website homepage",
-        ),
-        onPageReadyActions = listOf(
-            "move cursor to the element with id 'title' and click it",
-            "scroll to middle",
-            "scroll to top",
-            "get the text of the element with id 'title'"
-        ),
-        pageSummaryPrompt = "Tell me something about the page",
-        dataExtractionRules = "Extract the title and price of the product",
-        uriExtractionRules = "Links containing /dp/"
-    )
+    // Lazy to defer URL resolution until after Spring starts the mock server
+    private val request by lazy {
+        CommandRequest(
+            url = MOCK_PRODUCT_DETAIL_URL,
+            onBrowserLaunchedActions = listOf(
+                "clear browser cookies",
+                "goto the website homepage",
+            ),
+            onPageReadyActions = listOf(
+                "move cursor to the element with id 'title' and click it",
+                "scroll to middle",
+                "scroll to top",
+                "get the text of the element with id 'title'"
+            ),
+            pageSummaryPrompt = "Tell me something about the page",
+            dataExtractionRules = "Extract the title and price of the product",
+            uriExtractionRules = "Links containing /dp/"
+        )
+    }
     private val textContent = "This is a sample product page with title 'Sample Product' and price '$19.99'."
 
     @Test


### PR DESCRIPTION
## Problem

`PromptsTest` failed on CI with:

```
java.lang.IllegalStateException: Mock server port not found — set -Dmock.server.port=<port> or ensure the server has started.
    at ai.platon.pulsar.rest.api.common.PromptsTest.<init>(PromptsTest.kt:23)
```

The `request` property accessed `MOCK_PRODUCT_DETAIL_URL` during class initialization (Kotlin property initializer), before Spring starts the mock server.

## Fix

Changed to `by lazy` so URL resolution is deferred until the test method runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)