### PR TITLE
fix: add session-default to tested_commands() for E2E coverage

### DIFF
--- a/cli/browser4-cli/tests/e2e/mod.rs
+++ b/cli/browser4-cli/tests/e2e/mod.rs
@@ -4107,6 +4107,8 @@ fn tested_commands(include_batch_command: bool) -> HashSet<&'static str> {
         "open",
         "list",
         "close",
+        // test_session_default_*
+        "session-default",
         // test_close_*, test_close_all_*
         "close-all",
         // test_kill_all_*


### PR DESCRIPTION
One-line fix: `session-default` was marked `E2eCoverage::Tested` with four scenarios but never registered in `tested_commands()`, causing CI to fail on `test_e2e_command_coverage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)