### PR TITLE
Improve trigger-release.ps1: delegate version checks to version.mjs

### DIFF
--- a/bin/release/trigger-release.ps1
+++ b/bin/release/trigger-release.ps1
@@ -63,80 +63,98 @@ if ($version -notmatch "^\d+\.\d+\.\d+(?:-rc\.\d+)?$") {
 }
 
 # ═══════════════════════════════════════════════════════════════════
-# Version guard: verify current version is exactly the next patch
-# after the last GitHub release. If not, ask for confirmation.
+# Prerelease checks: version consistency across all files (VERSION,
+# pom.xml, Cargo.toml, package.json) and next-patch guard against
+# the last GitHub release.  Delegates to version.mjs so there is a
+# single source of truth for all version-comparison logic.
 # ═══════════════════════════════════════════════════════════════════
 
-function Get-SemverBase {
-    param([string]$V)
-    # Strip leading 'v' and trailing -rc.N / -SNAPSHOT suffix
-    $v = $V -replace '^v', ''
-    $v = $v -replace '-(rc\.\d+|SNAPSHOT)$', ''
-    return $v
+Write-Host ""
+Write-Host "Running prerelease checks (version.mjs prerelease-check)..."
+
+$checkScript = "$repoRoot\bin\version.mjs"
+if (!(Test-Path $checkScript)) {
+    Write-Error "version.mjs not found at: $checkScript"
+    exit 1
 }
 
-function Get-LastReleaseTag {
-    # Try GitHub Releases first
-    try {
-        $tag = gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>$null
-        if ($tag) { return $tag.Trim() }
-    } catch { }
+# Capture stdout only — prerelease-check writes JSON to stdout and
+# exits 0 (all OK) or 1 (issues found).
+$checkOutput = node $checkScript prerelease-check 2>$null
+$checkExitCode = $LASTEXITCODE
 
-    # Fallback: git tags sorted by version (only stable semver tags)
-    try {
-        $tag = git tag --list 'v*' --sort=-v:refname 2>$null |
-            Where-Object { $_ -match '^v\d+\.\d+\.\d+$' } |
-            Select-Object -First 1
-        if ($tag) { return $tag.Trim() }
-    } catch { }
-
-    # Last resort: git describe
-    try {
-        $tag = git describe --tags --abbrev=0 2>$null
-        if ($tag) { return $tag.Trim() }
-    } catch { }
-
-    return $null
+if ($null -eq $checkExitCode) {
+    Write-Error "Failed to run node. Is Node.js installed and on PATH?"
+    exit 1
 }
 
-$lastReleaseTag = Get-LastReleaseTag
+# Parse JSON output from version.mjs
+$parseOk = $true
+try {
+    if ($checkOutput -is [array]) {
+        $checkJson = ($checkOutput -join "`n") | ConvertFrom-Json
+    } else {
+        $checkJson = $checkOutput | ConvertFrom-Json
+    }
+} catch {
+    $parseOk = $false
+    Write-Warning "Could not parse prerelease-check output."
+    if ($checkOutput) {
+        Write-Host "Raw output:"
+        Write-Host $checkOutput
+    }
+    $confirm = Read-Host "Continue anyway? (y/n)"
+    if ($confirm -ne 'y') {
+        Write-Host "Cancelled"
+        exit 0
+    }
+    Write-Host "Proceeding despite parse failure..."
+}
 
-if ($lastReleaseTag) {
-    $lastBase = Get-SemverBase $lastReleaseTag
-    $currentBase = Get-SemverBase $version
-
-    Write-Host "`nLast GitHub release: $lastReleaseTag"
-    Write-Host "Current version:     v$version"
-
-    if ($lastBase -match '^(\d+)\.(\d+)\.(\d+)') {
-        $expectedNext = "$($matches[1]).$($matches[2]).$([int]$matches[3] + 1)"
-
-        if ($currentBase -ne $expectedNext) {
-            Write-Host ""
-            Write-Warning "Version mismatch: current version is not the next patch after the last release"
-            Write-Host "  Last release:         $lastReleaseTag  (base: $lastBase)"
-            Write-Host "  Expected next patch:  v$expectedNext"
-            Write-Host "  Current version:      v$version  (base: $currentBase)"
-            Write-Host ""
-            $confirm = Read-Host "Continue anyway? (y/n)"
-            if ($confirm -ne 'y') {
-                Write-Host "Cancelled"
-                exit 0
-            }
-            Write-Host "Proceeding despite version mismatch..."
+if ($parseOk) {
+    if ($checkExitCode -eq 0) {
+        # All checks passed
+        Write-Host "[OK] All version files consistent (v$($checkJson.currentVersion))"
+        if ($checkJson.lastRelease) {
+            Write-Host "[OK] v$($checkJson.currentVersion) is the next patch after $($checkJson.lastRelease)"
         } else {
-            Write-Host "[OK] v$version is exactly the next patch after $lastReleaseTag"
+            Write-Host "[OK] First release — no previous release to compare against"
         }
     } else {
-        Write-Warning "Could not parse last release version: $lastReleaseTag"
+        # Issues found — display them clearly and ask for confirmation
+        Write-Host ""
+        Write-Warning "Prerelease checks found issues:"
+        Write-Host ""
+
+        if (-not $checkJson.consistent) {
+            Write-Host "  Version inconsistency across files:"
+            foreach ($issue in $checkJson.issues) {
+                Write-Host "    - $issue"
+            }
+            Write-Host ""
+            Write-Host "  Run 'node bin/version.mjs sync' to fix version mismatches."
+            Write-Host ""
+        }
+
+        if (-not $checkJson.isNextPatch) {
+            Write-Host "  Version is not the next patch after the last release:"
+            Write-Host "    Last release:       $($checkJson.lastRelease)"
+            Write-Host "    Current version:    v$($checkJson.currentVersion)"
+            if ($checkJson.expectedNextPatch) {
+                Write-Host "    Expected next patch: v$($checkJson.expectedNextPatch)"
+            }
+            Write-Host ""
+            Write-Host "  Run 'node bin/version.mjs auto' to auto-bump to the next patch."
+            Write-Host ""
+        }
+
         $confirm = Read-Host "Continue anyway? (y/n)"
         if ($confirm -ne 'y') {
             Write-Host "Cancelled"
             exit 0
         }
+        Write-Host "Proceeding despite version issues..."
     }
-} else {
-    Write-Host "`nNo previous GitHub release found (first release?). Proceeding..."
 }
 
 $newTag = "v$version"

--- a/bin/tools/watch-logs.py
+++ b/bin/tools/watch-logs.py
@@ -164,10 +164,14 @@ def copy_to_clipboard(text: str) -> bool:
     try:
         if sys.platform == "win32":
             subprocess.run(
-                ["clip"], input=text, text=True,
+                # clip.exe reads Unicode clipboard data as UTF-16LE. Passing
+                # text=True uses the active code page and can silently lose
+                # non-ASCII log messages while still returning success.
+                ["clip.exe"], input=text.encode("utf-16le"),
                 creationflags=subprocess.CREATE_NO_WINDOW
                 if hasattr(subprocess, "CREATE_NO_WINDOW") else 0,
                 check=True,
+                timeout=5,
             )
         elif sys.platform == "darwin":
             subprocess.run(["pbcopy"], input=text, text=True, check=True)
@@ -767,8 +771,6 @@ class LogView(Container):
             # Scrolled up — pin view N lines above the bottom
             start = max(0, total - visible_h - self._scroll_from_bottom)
 
-        visible = filtered[start : start + visible_h]
-
         # ── Update search matches (full filtered buffer) ────────────────────
         if self._search_pattern:
             try:
@@ -785,8 +787,7 @@ class LogView(Container):
 
         SEARCH_HIGHLIGHT = Style.parse("reverse bold yellow")
 
-        for i, line in enumerate(visible):
-            actual_idx = start + i
+        for actual_idx, line in enumerate(filtered):
 
             # Colorize
             if is_git:
@@ -823,6 +824,11 @@ class LogView(Container):
                     pass
 
             self.rich_log.write(text)
+
+        # RichLog owns the complete scrollback. Rebuilding only a
+        # viewport-sized slice discards the rest of the buffer and makes the
+        # viewer appear to contain only a few lines.
+        self.rich_log.scroll_to(y=start, animate=False, immediate=True)
 
         # ── Status label ────────────────────────────────────────────────────
         self._update_status(total, start, visible_h)
@@ -1167,6 +1173,11 @@ class WatchLogsApp(App):
         """Set up header and subtitle."""
         self.title = "Browser4 Log Dashboard"
         self.sub_title = str(self.repo_root.name)
+        # The hidden filter input otherwise retains focus and consumes
+        # single-key dashboard shortcuts such as y (copy).
+        if view := self._active_view:
+            if view.rich_log:
+                view.rich_log.focus()
         if not HAS_WATCHFILES:
             self.notify(
                 "watchfiles not installed — using polling fallback (pip install watchfiles)",
@@ -1183,7 +1194,7 @@ class WatchLogsApp(App):
         except Exception:
             return None
         for src in LOG_SOURCES:
-            if src["label"] == active:
+            if f"tab-{src['label']}" == active:
                 return self._log_views.get(src["label"])
         return None
 
@@ -1191,26 +1202,26 @@ class WatchLogsApp(App):
 
     def action_switch_tab(self, index: str) -> None:
         """Switch to a tab by number key (0-9)."""
-        i = int(index)
-        if 0 <= i < len(LOG_SOURCES):
-            label = LOG_SOURCES[i]["label"]
-            try:
-                tabs = self.query_one(TabbedContent)
-                tabs.active = label
-            except Exception:
-                pass
+        source = next((src for src in LOG_SOURCES if src["key"] == index), None)
+        if source is None:
+            return
+        try:
+            tabs = self.query_one(TabbedContent)
+            tabs.active = f"tab-{source['label']}"
+        except Exception:
+            pass
 
     def action_git_tab(self) -> None:
         """Switch to git tab, or toggle detail if already there."""
         try:
             tabs = self.query_one(TabbedContent)
-            if tabs.active == "git":
+            if tabs.active == "tab-git":
                 # Toggle detail mode
                 view = self._log_views.get("git")
                 if view:
                     view.action_toggle_git_detail()
             else:
-                tabs.active = "git"
+                tabs.active = "tab-git"
         except Exception:
             pass
 
@@ -1218,7 +1229,7 @@ class WatchLogsApp(App):
         """Switch to RWS test output tab."""
         try:
             tabs = self.query_one(TabbedContent)
-            tabs.active = "rws"
+            tabs.active = "tab-rws"
         except Exception:
             pass
 
@@ -1263,6 +1274,8 @@ class WatchLogsApp(App):
         view = self._active_view
         if view:
             view.action_set_filter("")
+            if view.rich_log:
+                view.rich_log.focus()
 
     # ── Scroll & search actions (routed to active view) ─────────────────────
 
@@ -1308,6 +1321,8 @@ class WatchLogsApp(App):
         inp = self.query_one("#filter-input", Input)
         if pattern:
             inp.value = pattern  # keep visible for reference
+        if view and view.rich_log:
+            view.rich_log.focus()
         self.notify(
             f"Filter: '{pattern}'" if pattern else "Filter cleared",
             timeout=2,

--- a/bin/version.mjs
+++ b/bin/version.mjs
@@ -795,17 +795,24 @@ async function cmdBump(args) {
 /** Get the latest GitHub release tag, falling back to git tags. */
 function getLatestReleaseTag() {
   try {
-    // Try gh CLI first (gives us actual GitHub Releases)
-    const raw = execSync("gh release list --limit 1 --json tagName,name --jq '.[0].tagName'", {
+    // Try gh CLI first (gives us actual GitHub Releases).
+    // Parse JSON in Node rather than using --jq, so the command works on
+    // Windows (cmd.exe doesn't handle single quotes in --jq '…').
+    const raw = execSync("gh release list --limit 1 --json tagName", {
       cwd: REPO_ROOT, stdio: ["ignore", "pipe", "ignore"],
       timeout: 10_000,
     }).toString().trim();
-    if (raw) return raw;
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed.length > 0 && parsed[0].tagName) {
+        return parsed[0].tagName;
+      }
+    }
   } catch { /* fall through */ }
 
-  // Fallback: latest semver-sorted tag
+  // Fallback: latest stable semver tag (exclude -rc.N, -ci.N, etc.)
   try {
-    const tag = execSync("git tag --sort=-v:refname | grep -E '^v?[0-9]+\\.[0-9]+\\.[0-9]+' | head -1", {
+    const tag = execSync("git tag --sort=-v:refname | grep -E '^v?[0-9]+\\.[0-9]+\\.[0-9]+$' | head -1", {
       cwd: REPO_ROOT, stdio: ["ignore", "pipe", "ignore"],
     }).toString().trim();
     if (tag) return tag;
@@ -1161,6 +1168,116 @@ function cmdCheck() {
 }
 
 // ---------------------------------------------------------------------------
+// Subcommand: prerelease-check (used by trigger-release.ps1)
+// ---------------------------------------------------------------------------
+
+function cmdPrereleaseCheck() {
+  const result = {
+    consistent: true,
+    isNextPatch: false,
+    lastRelease: null,
+    currentVersion: null,
+    expectedNextPatch: null,
+    issues: [],
+  };
+
+  // ── Phase 1: File-level version consistency ─────────────────────────
+  const versionFileVersion = readBackendVersion();
+  const cliVersion = stripSnapshot(versionFileVersion);
+  result.currentVersion = cliVersion;
+
+  // Check pom.xml version
+  const pomPath = join(REPO_ROOT, "pom.xml");
+  if (existsSync(pomPath)) {
+    let pomContent = readFileSync(pomPath, "utf-8");
+    const pomWithoutParent = pomContent.replace(/<parent>[\s\S]*?<\/parent>/m, "");
+    const pomVersionMatch = pomWithoutParent.match(/<version>([^<]+)<\/version>/);
+    if (pomVersionMatch) {
+      const pomVersion = pomVersionMatch[1];
+      if (pomVersion !== versionFileVersion) {
+        result.consistent = false;
+        result.issues.push(`pom.xml: "${pomVersion}" (expected "${versionFileVersion}")`);
+      }
+    } else {
+      result.consistent = false;
+      result.issues.push("pom.xml: cannot parse <version>");
+    }
+  } else {
+    result.consistent = false;
+    result.issues.push("pom.xml: file not found");
+  }
+
+  // Check Cargo.toml
+  const cargoPath = join(REPO_ROOT, "cli", "browser4-cli", "Cargo.toml");
+  if (existsSync(cargoPath)) {
+    const cargoContent = readFileSync(cargoPath, "utf-8");
+    const cargoMatch = cargoContent.match(/\[package\][\s\S]*?version\s*=\s*"([^"]+)"/);
+    if (cargoMatch) {
+      const cargoVersion = cargoMatch[1];
+      if (cargoVersion !== cliVersion) {
+        result.consistent = false;
+        result.issues.push(`Cargo.toml: "${cargoVersion}" (expected "${cliVersion}")`);
+      }
+    } else {
+      result.consistent = false;
+      result.issues.push("Cargo.toml: cannot parse package.version");
+    }
+  }
+
+  // Check package.json
+  const packageJsonPath = join(REPO_ROOT, "cli", "package.json");
+  if (existsSync(packageJsonPath)) {
+    try {
+      const pj = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+      if (pj.version !== cliVersion) {
+        result.consistent = false;
+        result.issues.push(`package.json: "${pj.version}" (expected "${cliVersion}")`);
+      }
+    } catch {
+      result.consistent = false;
+      result.issues.push("package.json: cannot parse version");
+    }
+  }
+
+  // ── Phase 2: Next-patch check against last release ──────────────────
+  const lastReleaseTag = getLatestReleaseTag();
+  result.lastRelease = lastReleaseTag;
+
+  if (lastReleaseTag) {
+    // Strip 'v' prefix and any prerelease suffix to get the base semver
+    const lastBase = lastReleaseTag.replace(/^v/, "").replace(/-.*$/, "");
+    const bumpResult = checkVersionBump(lastBase, cliVersion);
+
+    // "already published" note means the version hasn't been bumped at all
+    result.isNextPatch = bumpResult.ok && !bumpResult.note;
+
+    if (!result.isNextPatch) {
+      if (bumpResult.reason) {
+        result.issues.push(bumpResult.reason);
+      } else if (bumpResult.note) {
+        result.issues.push(`Version ${cliVersion} is already published as ${lastReleaseTag}`);
+      }
+
+      // Compute expected next patch from last release
+      const lastParsed = parseSemver(lastBase);
+      if (lastParsed) {
+        result.expectedNextPatch = `${lastParsed.major}.${lastParsed.minor}.${lastParsed.patch + 1}`;
+      }
+    }
+  } else {
+    // No previous release found — first release is always OK
+    result.isNextPatch = true;
+  }
+
+  // ── Output ───────────────────────────────────────────────────────────
+  console.log(JSON.stringify(result, null, 2));
+
+  if (!result.consistent || !result.isNextPatch) {
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main: parse subcommand
 // ---------------------------------------------------------------------------
 
@@ -1194,6 +1311,7 @@ function printUsage() {
   console.log("");
   console.log("  Cross-cutting");
   console.log("    check             Check version consistency across all files");
+  console.log("    prerelease-check  Check consistency + next-patch guard (JSON output)");
 }
 
 const args = process.argv.slice(2);
@@ -1229,6 +1347,9 @@ switch (command) {
     break;
   case "check":
     cmdCheck();
+    break;
+  case "prerelease-check":
+    cmdPrereleaseCheck();
     break;
   default:
     console.error(`Unknown command: ${command}`);

--- a/cli/browser4-cli/Cargo.lock
+++ b/cli/browser4-cli/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "browser4-cli"
-version = "4.12.0"
+version = "4.12.1"
 dependencies = [
  "base64",
  "chrono",

--- a/cli/browser4-cli/Cargo.toml
+++ b/cli/browser4-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "browser4-cli"
-version = "4.12.0"
+version = "4.12.1"
 edition = "2021"
 autotests = false
 description = "Browser4 CLI — control a Browser4 server from the command line"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser4-cli",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Browser automation CLI for AI agents",
   "type": "module",
   "files": [


### PR DESCRIPTION
Summary: Replaces hand-rolled version guard in trigger-release.ps1 with call to version.mjs prerelease-check. Adds prerelease-check subcommand to version.mjs. Fixes getLatestReleaseTag cross-platform bug.