### PR TITLE
feat(gui): implement watch-logs.py as Node.js web log dashboard

### DIFF
--- a/coworker/gui/README.md
+++ b/coworker/gui/README.md
@@ -29,6 +29,7 @@ Then open **http://127.0.0.1:8090**.
 |-------|------|-------------|
 | `GET /` | `frontend/index.html` | Main Coworker Task Manager — pipeline dashboard with stage tabs and file tree |
 | `GET /issues/review` | `frontend/issue-review.html` | Issue Review SPA — review `.issues.md` files from the `issues/review` queue |
+| `GET /logs` | `frontend/watch-logs.html` | Log Dashboard — real-time log viewer for all Browser4 log sources |
 
 ## API
 
@@ -76,9 +77,10 @@ When the "Auto-approve" checkbox is checked in the Issue Review SPA, the mark-do
 ├── package.json       # express + cors only
 ├── server.js          # All routes (~680 LOC)
 ├── frontend/
-│   ├── index.html     # Task Manager SPA
-│   ├── issue-review.html  # Issue Review SPA
-│   └── issue-model.js     # Shared issue model library
+│   ├── index.html          # Task Manager SPA
+│   ├── issue-review.html   # Issue Review SPA
+│   ├── watch-logs.html     # Log Dashboard SPA
+│   └── issue-model.js      # Shared issue model library
 └── README.md
 ```
 

--- a/coworker/gui/frontend/index.html
+++ b/coworker/gui/frontend/index.html
@@ -552,6 +552,7 @@ dialog .delete-warning {
     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M3 9h18"/><path d="M9 21V9"/><circle cx="7.5" cy="6" r="1" fill="currentColor" stroke="none"/><circle cx="12.5" cy="6" r="1" fill="currentColor" stroke="none"/><circle cx="17.5" cy="6" r="1" fill="currentColor" stroke="none"/></svg>
     <h1>Coworker Task Manager</h1>
     <a href="/issues/review" style="color:#a78bfa;font-size:0.72rem;text-decoration:none;margin-left:6px;opacity:0.75;" title="Review issue files">→ Review</a>
+    <a href="/logs" style="color:#a78bfa;font-size:0.72rem;text-decoration:none;margin-left:4px;opacity:0.75;" title="Log dashboard">→ Logs</a>
   </div>
   <div class="header-right">
     <div class="total-badge">

--- a/coworker/gui/frontend/index.html
+++ b/coworker/gui/frontend/index.html
@@ -131,6 +131,15 @@ body {
 .app-brand svg { flex-shrink: 0; }
 .app-brand h1 { font-size: 1.05rem; font-weight: 600; margin: 0; color: #f1f5f9; letter-spacing: -0.01em; }
 .header-right { display: flex; align-items: center; gap: 10px; }
+.header-nav { display: flex; align-items: center; gap: 4px; }
+.header-nav a {
+  color: rgba(255,255,255,0.6); text-decoration: none;
+  font-size: 0.72rem; padding: 3px 10px; border-radius: var(--radius-sm);
+  transition: all var(--transition); font-weight: 500;
+  border: 1px solid transparent;
+}
+.header-nav a:hover { color: #fff; background: rgba(255,255,255,0.08); }
+.header-nav a.active { color: #fff; background: rgba(255,255,255,0.12); border-color: rgba(255,255,255,0.2); }
 .app-header .total-badge {
   display: flex; align-items: center; gap: 6px;
   background: rgba(255,255,255,0.1); color: #e2e8f0;
@@ -551,10 +560,13 @@ dialog .delete-warning {
   <div class="app-brand">
     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M3 9h18"/><path d="M9 21V9"/><circle cx="7.5" cy="6" r="1" fill="currentColor" stroke="none"/><circle cx="12.5" cy="6" r="1" fill="currentColor" stroke="none"/><circle cx="17.5" cy="6" r="1" fill="currentColor" stroke="none"/></svg>
     <h1>Coworker Task Manager</h1>
-    <a href="/issues/review" style="color:#a78bfa;font-size:0.72rem;text-decoration:none;margin-left:6px;opacity:0.75;" title="Review issue files">→ Review</a>
-    <a href="/logs" style="color:#a78bfa;font-size:0.72rem;text-decoration:none;margin-left:4px;opacity:0.75;" title="Log dashboard">→ Logs</a>
   </div>
   <div class="header-right">
+    <nav class="header-nav">
+      <a href="/" class="active">Tasks</a>
+      <a href="/issues/review">Review</a>
+      <a href="/logs">Logs</a>
+    </nav>
     <div class="total-badge">
       <span>pipeline</span>
       <strong id="total-badge">—</strong>

--- a/coworker/gui/frontend/issue-review.html
+++ b/coworker/gui/frontend/issue-review.html
@@ -155,9 +155,16 @@ body {
 .app-brand { display: flex; align-items: center; gap: 10px; }
 .app-brand svg { flex-shrink: 0; }
 .app-brand h1 { font-size: 1.05rem; font-weight: 600; margin: 0; color: #f1f5f9; letter-spacing: -0.01em; }
-.app-brand .nav-link { color: #a78bfa; font-size: 0.72rem; text-decoration: none; margin-left: 6px; opacity: 0.75; }
-.app-brand .nav-link:hover { opacity: 1; }
 .header-right { display: flex; align-items: center; gap: 10px; }
+.header-nav { display: flex; align-items: center; gap: 4px; }
+.header-nav a {
+  color: rgba(255,255,255,0.6); text-decoration: none;
+  font-size: 0.72rem; padding: 3px 10px; border-radius: var(--radius-sm);
+  transition: all var(--transition); font-weight: 500;
+  border: 1px solid transparent;
+}
+.header-nav a:hover { color: #fff; background: rgba(255,255,255,0.08); }
+.header-nav a.active { color: #fff; background: rgba(255,255,255,0.12); border-color: rgba(255,255,255,0.2); }
 .header-stats { display: flex; align-items: center; gap: 12px; }
 .header-stats .stat-item {
   display: flex; align-items: center; gap: 5px;
@@ -1038,9 +1045,13 @@ body {
   <div class="app-brand">
     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/><path d="M9 14l2 2 4-4"/></svg>
     <h1>Issue Review</h1>
-    <a href="/" class="nav-link" title="Back to Task Manager">← Tasks</a>
   </div>
   <div class="header-right">
+    <nav class="header-nav">
+      <a href="/">Tasks</a>
+      <a href="/issues/review" class="active">Review</a>
+      <a href="/logs">Logs</a>
+    </nav>
     <div class="header-stats" id="header-stats">
       <div class="stat-item"><span class="stat-num" id="stat-files">—</span> files</div>
       <div class="stat-divider"></div>

--- a/coworker/gui/frontend/watch-logs.html
+++ b/coworker/gui/frontend/watch-logs.html
@@ -166,9 +166,9 @@ body {
   box-shadow: var(--shadow-sm);
 }
 .source-tab {
-  display: inline-flex; align-items: center; gap: 5px;
-  padding: 5px 12px;
-  font-size: 0.74rem; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 4px 8px;
+  font-size: 0.7rem; font-weight: 500;
   cursor: pointer; user-select: none;
   border: 1px solid transparent;
   background: transparent; color: var(--text-secondary);
@@ -190,11 +190,6 @@ body {
   opacity: 0.7;
 }
 .source-tab.active .tab-key { background: rgba(255,255,255,0.2); opacity: 1; }
-.source-tab .tab-desc {
-  font-size: 0.62rem; opacity: 0.6; font-weight: 400;
-}
-.source-tab.active .tab-desc { opacity: 0.85; }
-
 /* ═══════════════════════════════════════════════════════════════════════
    Main Log Display
    ═══════════════════════════════════════════════════════════════════════ */
@@ -325,8 +320,7 @@ body {
    ═══════════════════════════════════════════════════════════════════════ */
 @media (max-width: 768px) {
   .source-tabs { padding: 3px 0.5rem; }
-  .source-tab { padding: 4px 8px; font-size: 0.7rem; }
-  .source-tab .tab-desc { display: none; }
+  .source-tab { padding: 3px 6px; font-size: 0.65rem; }
   .log-display { font-size: 0.7rem; }
 }
 </style>
@@ -490,8 +484,7 @@ function renderTabs() {
       '" onclick="selectSourceById(\'' + src.label + '\')" title="' +
       escHtml(src.desc) + ' (' + src.key + ')">' +
       '<span class="tab-key">' + escHtml(src.key) + '</span>' +
-      escHtml(src.label) +
-      '<span class="tab-desc">' + escHtml(src.desc) + '</span></div>';
+      escHtml(src.label) + '</div>';
   }
   container.innerHTML = html;
 }

--- a/coworker/gui/frontend/watch-logs.html
+++ b/coworker/gui/frontend/watch-logs.html
@@ -1,0 +1,1082 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Log Dashboard — Browser4</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+<style>
+/* ═══════════════════════════════════════════════════════════════════════
+   Design Tokens — Light & Dark
+   ═══════════════════════════════════════════════════════════════════════ */
+:root {
+  --font: system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Consolas', 'Fira Code', monospace;
+  --radius-sm: 6px; --radius: 10px; --radius-lg: 14px;
+  --transition: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+html[data-theme="light"] {
+  --bg-root:        #f7f5f2;
+  --bg-surface:     #ffffff;
+  --bg-raised:      #fafaf9;
+  --bg-inset:       #f1efec;
+  --bg-hover:       #f3f0ed;
+  --bg-selected:    #eeecfa;
+  --border:         #e4e1dd;
+  --border-light:   #f0edea;
+  --text-primary:   #1e1b2e;
+  --text-secondary: #5c586b;
+  --text-muted:     #9e99aa;
+  --text-on-dark:   #f2f0f5;
+  --accent:         #6c5ce7;
+  --accent-light:   #a29bfe;
+  --accent-bg:      #f4f2ff;
+  --accent-border:  #d5d1f5;
+  --danger:         #e53e3e;
+  --danger-bg:      #fff5f5;
+  --success:        #38a169;
+  --success-bg:     #f0fff4;
+  --info:           #3b82f6;
+  --info-bg:        #eff6ff;
+  --warning:        #d69e2e;
+  --warning-bg:     #fffff0;
+  --header-bg:      #1a1730;
+  --header-bg-end:  #2d2752;
+  --shadow-sm:      0 1px 2px rgba(0,0,0,0.04);
+  --shadow:         0 1px 3px rgba(0,0,0,0.05), 0 1px 2px rgba(0,0,0,0.03);
+  --shadow-md:      0 4px 14px rgba(0,0,0,0.06);
+  --scrollbar-thumb:#d0ccc7;
+  --log-bg:         #fafaf9;
+  --log-text:       #1e1b2e;
+  --log-dim:        #9e99aa;
+  --log-red:        #e53e3e;
+  --log-yellow:     #b7791f;
+  --log-cyan:       #2b6cb0;
+  --log-green:      #276749;
+  --log-white:      #1e1b2e;
+  --log-magenta:    #6c5ce7;
+  --search-highlight-bg: #fefcbf;
+  --search-current-bg:   #fbd38d;
+}
+
+html[data-theme="dark"] {
+  --bg-root:        #0b1120;
+  --bg-surface:     #0f1923;
+  --bg-raised:      #152233;
+  --bg-inset:       #0a1018;
+  --bg-hover:       #182a3f;
+  --bg-selected:    #1a2e4a;
+  --border:         #1e2d42;
+  --border-light:   #18273a;
+  --text-primary:   #e2e0e8;
+  --text-secondary: #a4a0b8;
+  --text-muted:     #6b6580;
+  --text-on-dark:   #f2f0f5;
+  --accent:         #a78bfa;
+  --accent-light:   #c4b5fd;
+  --accent-bg:      #1e2040;
+  --accent-border:  #3d3570;
+  --danger:         #fc8181;
+  --danger-bg:      #2d1520;
+  --success:        #68d391;
+  --success-bg:     #13281e;
+  --info:           #60a5fa;
+  --info-bg:        #152238;
+  --warning:        #fbbf24;
+  --warning-bg:     #2d2410;
+  --header-bg:      #090d1c;
+  --header-bg-end:  #141f36;
+  --shadow-sm:      0 1px 2px rgba(0,0,0,0.18);
+  --shadow:         0 1px 3px rgba(0,0,0,0.24), 0 1px 2px rgba(0,0,0,0.16);
+  --shadow-md:      0 4px 14px rgba(0,0,0,0.28);
+  --scrollbar-thumb:#2d3a5c;
+  --log-bg:         #0a0e14;
+  --log-text:       #d4d0d8;
+  --log-dim:        #5c5870;
+  --log-red:        #ff6b6b;
+  --log-yellow:     #ffd166;
+  --log-cyan:       #5ccfe6;
+  --log-green:      #7fd97f;
+  --log-white:      #e2e0e8;
+  --log-magenta:    #c4b5fd;
+  --search-highlight-bg: #5c4820;
+  --search-current-bg:   #7c5020;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Base
+   ═══════════════════════════════════════════════════════════════════════ */
+* { box-sizing: border-box; }
+body {
+  margin: 0; min-height: 100vh; display: flex; flex-direction: column;
+  font-family: var(--font); background: var(--bg-root); color: var(--text-primary);
+}
+* { scrollbar-width: thin; scrollbar-color: var(--scrollbar-thumb) transparent; }
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 10px; border: 2px solid transparent; background-clip: padding-box; }
+::-webkit-scrollbar-corner { background: transparent; }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Header
+   ═══════════════════════════════════════════════════════════════════════ */
+.app-header {
+  background: linear-gradient(135deg, var(--header-bg) 0%, var(--header-bg-end) 100%);
+  color: #f1f5f9;
+  padding: 0 1.25rem; height: 44px;
+  display: flex; align-items: center; justify-content: space-between;
+  flex-shrink: 0; z-index: 100;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.06) inset, 0 2px 10px rgba(0,0,0,0.25);
+}
+.app-brand { display: flex; align-items: center; gap: 10px; }
+.app-brand svg { flex-shrink: 0; }
+.app-brand h1 { font-size: 0.95rem; font-weight: 600; margin: 0; color: #f1f5f9; letter-spacing: -0.01em; }
+.header-right { display: flex; align-items: center; gap: 10px; }
+.header-nav { display: flex; align-items: center; gap: 4px; }
+.header-nav a {
+  color: rgba(255,255,255,0.6); text-decoration: none;
+  font-size: 0.72rem; padding: 3px 10px; border-radius: var(--radius-sm);
+  transition: all var(--transition); font-weight: 500;
+  border: 1px solid transparent;
+}
+.header-nav a:hover { color: #fff; background: rgba(255,255,255,0.08); }
+.header-nav a.active { color: #fff; background: rgba(255,255,255,0.12); border-color: rgba(255,255,255,0.2); }
+.theme-toggle {
+  display: flex; align-items: center; justify-content: center;
+  width: 30px; height: 30px; border-radius: 50%;
+  border: 1px solid rgba(255,255,255,0.15);
+  background: rgba(255,255,255,0.06);
+  color: #e2e8f0; cursor: pointer;
+  font-size: 0.9rem; transition: all var(--transition);
+  line-height: 1; padding: 0;
+}
+.theme-toggle:hover { background: rgba(255,255,255,0.15); border-color: rgba(255,255,255,0.25); }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Source Tabs
+   ═══════════════════════════════════════════════════════════════════════ */
+.source-tabs {
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+  padding: 4px 0.75rem;
+  flex-shrink: 0;
+  display: flex; align-items: center; gap: 2px;
+  overflow-x: auto; white-space: nowrap;
+  box-shadow: var(--shadow-sm);
+}
+.source-tab {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 5px 12px;
+  font-size: 0.74rem; font-weight: 500;
+  cursor: pointer; user-select: none;
+  border: 1px solid transparent;
+  background: transparent; color: var(--text-secondary);
+  border-radius: var(--radius-sm);
+  transition: all var(--transition);
+  flex-shrink: 0;
+}
+.source-tab:hover { color: var(--text-primary); background: var(--bg-hover); }
+.source-tab.active {
+  color: var(--text-on-dark);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.source-tab .tab-key {
+  font-size: 0.58rem; font-weight: 700;
+  background: rgba(0,0,0,0.12); color: inherit;
+  border-radius: 3px; padding: 0px 4px; min-width: 16px;
+  text-align: center; line-height: 1.6;
+  opacity: 0.7;
+}
+.source-tab.active .tab-key { background: rgba(255,255,255,0.2); opacity: 1; }
+.source-tab .tab-desc {
+  font-size: 0.62rem; opacity: 0.6; font-weight: 400;
+}
+.source-tab.active .tab-desc { opacity: 0.85; }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Main Log Display
+   ═══════════════════════════════════════════════════════════════════════ */
+.log-viewer {
+  flex: 1; display: flex; flex-direction: column;
+  overflow: hidden; position: relative;
+  background: var(--log-bg);
+}
+.log-display {
+  flex: 1; overflow-y: auto; overflow-x: auto;
+  font-family: var(--font-mono); font-size: 0.78rem;
+  line-height: 1.55; padding: 4px 0;
+  color: var(--log-text);
+  user-select: text; -webkit-user-select: text;
+  outline: none;
+}
+.log-display:focus { outline: none; }
+.log-line {
+  white-space: pre; padding: 0 12px;
+  min-height: 1.55em;
+}
+.log-line:hover { background: rgba(128,128,128,0.04); }
+
+/* ── Severity color spans ───────────────────────────────────────────── */
+.sev-FATAL, .sev-ERROR, .sev-SEVERE { color: var(--log-red); font-weight: 700; }
+.sev-WARN, .sev-WARNING { color: var(--log-yellow); }
+.sev-INFO { color: var(--log-white); }
+.sev-DEBUG, .sev-TRACE { color: var(--log-dim); }
+.sev-dim { color: var(--log-dim); }
+
+/* ── Git-specific ───────────────────────────────────────────────────── */
+.git-header { color: var(--log-cyan); }
+.git-commit { color: var(--log-yellow); font-weight: 700; }
+.git-author { color: var(--log-cyan); }
+.git-date   { color: var(--log-dim); }
+.git-message { color: var(--log-white); }
+.git-graph  { color: var(--log-dim); }
+.git-ref-head { color: var(--log-cyan); font-weight: 700; }
+.git-ref-tag  { color: var(--log-yellow); font-weight: 700; }
+.git-ref-remote { color: var(--log-green); }
+
+/* ── RWS-specific ───────────────────────────────────────────────────── */
+.rws-step-start { color: var(--log-cyan); font-weight: 700; }
+.rws-step-pass  { color: var(--log-green); font-weight: 700; }
+.rws-step-fail  { color: var(--log-red); font-weight: 700; }
+.rws-abort      { color: var(--log-red); font-weight: 700; background: rgba(255,0,0,0.1); }
+.rws-progress   { color: var(--log-dim); }
+
+/* ── Search highlight ───────────────────────────────────────────────── */
+.log-line .search-match { background: var(--search-highlight-bg); border-radius: 2px; }
+.log-line .search-current { background: var(--search-current-bg); border-radius: 2px; font-weight: 700; }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Status Bar
+   ═══════════════════════════════════════════════════════════════════════ */
+.log-status {
+  height: 26px; padding: 0 12px;
+  display: flex; align-items: center; gap: 12px;
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border);
+  font-size: 0.7rem; color: var(--text-muted);
+  flex-shrink: 0; user-select: none;
+}
+.log-status .status-badge {
+  font-weight: 600; font-size: 0.65rem;
+  padding: 1px 7px; border-radius: 10px;
+}
+.log-status .status-badge.live { background: var(--success-bg); color: var(--success); }
+.log-status .status-badge.paused { background: var(--warning-bg); color: var(--warning); }
+.log-status .status-badge.filtered { background: var(--info-bg); color: var(--info); }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Filter Bar
+   ═══════════════════════════════════════════════════════════════════════ */
+.filter-bar {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 12px;
+  background: var(--bg-raised);
+  border-top: 1px solid var(--accent-border);
+  flex-shrink: 0;
+}
+.filter-bar input {
+  flex: 1; padding: 4px 10px; border-radius: var(--radius-sm);
+  border: 1px solid var(--border); font-size: 0.78rem;
+  font-family: var(--font-mono);
+  background: var(--bg-inset); color: var(--text-primary);
+  transition: all var(--transition);
+}
+.filter-bar input:focus { outline: none; border-color: var(--accent); background: var(--bg-surface); }
+.filter-bar input::placeholder { color: var(--text-muted); }
+.filter-bar .filter-hint {
+  font-size: 0.65rem; color: var(--text-muted); white-space: nowrap;
+}
+.filter-bar .filter-count {
+  font-size: 0.7rem; color: var(--info); font-weight: 600; white-space: nowrap;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Empty / Loading state
+   ═══════════════════════════════════════════════════════════════════════ */
+.log-placeholder {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  height: 100%; color: var(--text-muted); font-size: 0.85rem; gap: 0.5rem;
+}
+.log-placeholder .placeholder-icon { font-size: 2.5rem; opacity: 0.3; }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Toast
+   ═══════════════════════════════════════════════════════════════════════ */
+.toast-container {
+  position: fixed; bottom: 2rem; right: 1.25rem; z-index: 9999;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.toast {
+  padding: 10px 16px; border-radius: var(--radius);
+  font-size: 0.8rem; font-weight: 500;
+  box-shadow: var(--shadow-md);
+  animation: toastSlideIn 0.25s ease-out;
+  max-width: 380px; display: flex; align-items: center; gap: 8px;
+}
+.toast.error { background: var(--danger-bg); color: var(--danger); border: 1px solid var(--danger-bg); }
+.toast.success { background: var(--success-bg); color: var(--success); border: 1px solid var(--success-bg); }
+.toast.info { background: var(--info-bg); color: var(--info); border: 1px solid var(--info-bg); }
+@keyframes toastSlideIn { from { opacity: 0; transform: translateX(16px); } to { opacity: 1; transform: translateX(0); } }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Responsive
+   ═══════════════════════════════════════════════════════════════════════ */
+@media (max-width: 768px) {
+  .source-tabs { padding: 3px 0.5rem; }
+  .source-tab { padding: 4px 8px; font-size: 0.7rem; }
+  .source-tab .tab-desc { display: none; }
+  .log-display { font-size: 0.7rem; }
+}
+</style>
+</head>
+<body>
+
+<!-- ═══════ HEADER ═══════ -->
+<header class="app-header">
+  <div class="app-brand">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>
+    </svg>
+    <h1>Browser4 Log Dashboard</h1>
+  </div>
+  <div class="header-right">
+    <nav class="header-nav">
+      <a href="/">Tasks</a>
+      <a href="/issues/review">Review</a>
+      <a href="/logs" class="active">Logs</a>
+    </nav>
+    <button class="theme-toggle" id="theme-toggle" title="Toggle dark mode" onclick="toggleTheme()">☀</button>
+  </div>
+</header>
+
+<!-- ═══════ SOURCE TABS ═══════ -->
+<nav class="source-tabs" id="source-tabs">
+  <!-- Populated by JS -->
+</nav>
+
+<!-- ═══════ LOG VIEWER ═══════ -->
+<main class="log-viewer" id="log-viewer">
+  <div class="log-display" id="log-display" tabindex="-1">
+    <div class="log-placeholder">
+      <span class="placeholder-icon">📋</span>
+      <p>Select a log source to begin</p>
+    </div>
+  </div>
+  <div class="log-status" id="log-status">
+    <span>Ready</span>
+  </div>
+</main>
+
+<!-- ═══════ FILTER BAR ═══════ -->
+<div class="filter-bar" id="filter-bar" style="display:none;">
+  <span style="color:var(--accent);flex-shrink:0;">🔍</span>
+  <input type="text" id="filter-input" placeholder="regex filter (Enter to apply, Esc to clear)" autocomplete="off">
+  <span class="filter-hint">F3 next · Shift+F3 prev</span>
+  <span class="filter-count" id="filter-count"></span>
+</div>
+
+<!-- ═══════ TOAST ═══════ -->
+<div class="toast-container" id="toast-container"></div>
+
+<!-- ═══════ SCRIPTS ═══════ -->
+<script>
+// ── Theme ──────────────────────────────────────────────────────────────
+(function() {
+  var saved = localStorage.getItem('coworker-gui-theme');
+  if (saved) document.documentElement.setAttribute('data-theme', saved);
+  if (!saved) document.documentElement.setAttribute('data-theme', 'dark');
+})();
+
+function toggleTheme() {
+  var current = document.documentElement.getAttribute('data-theme');
+  var next = current === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('coworker-gui-theme', next);
+  document.getElementById('theme-toggle').textContent = next === 'dark' ? '☀' : '🌙';
+}
+
+(function setThemeIcon() {
+  var current = document.documentElement.getAttribute('data-theme');
+  document.getElementById('theme-toggle').textContent = current === 'dark' ? '☀' : '🌙';
+})();
+
+// ── Log Source Definitions ─────────────────────────────────────────────
+var LOG_SOURCES = [
+  { key: "1", label: "pulsar",  desc: "Root backend",         paths: ["logs/pulsar.log"] },
+  { key: "2", label: "server",  desc: "Server / framework",   paths: ["logs/pulsar.s.log"] },
+  { key: "3", label: "browser", desc: "Browser / CDP ops",    paths: ["logs/pulsar.bs.log"] },
+  { key: "4", label: "api",     desc: "Scrape API tasks",     paths: ["logs/pulsar.api.log"] },
+  { key: "5", label: "pages",   desc: "Page processing",      paths: ["logs/pulsar.pg.log"] },
+  { key: "6", label: "coworker","desc": "Coworker task runner",paths: ["__coworker__"] },
+  { key: "7", label: "build",   desc: "Spring Boot build",    paths: [".build/spring-boot.log"] },
+  { key: "8", label: "startup", desc: "Server startup log",   paths: ["__startup__"] },
+  { key: "9", label: "combined","desc": "pulsar + server + browser", paths: ["logs/pulsar.log", "logs/pulsar.s.log", "logs/pulsar.bs.log"] },
+  { key: "0", label: "git",     desc: "Git log",              paths: ["__git__"] },
+  { key: "r", label: "rws",     desc: "RWS test output",      paths: ["__rws__"] },
+];
+
+// ── State ──────────────────────────────────────────────────────────────
+var state = {
+  activeSource: null,
+  positions: {},
+  paused: false,
+  filterRegex: null,
+  filterPattern: '',
+  searchPattern: '',
+  searchMatches: [],
+  searchIdx: -1,
+  scrollFromBottom: 0,
+  pollTimer: null,
+  gitDetail: false,
+  gitLastHash: '',
+  maxLines: 5000,
+  pollInterval: 500,
+};
+
+// ── API ────────────────────────────────────────────────────────────────
+async function apiGet(url) {
+  var res = await fetch(url);
+  if (!res.ok) {
+    var body = await res.json().catch(function() { return { error: res.statusText }; });
+    throw new Error(body.error || 'HTTP ' + res.status);
+  }
+  return res.json();
+}
+
+async function apiPost(url, body) {
+  var res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    var eb = await res.json().catch(function() { return { error: res.statusText }; });
+    throw new Error(eb.error || 'HTTP ' + res.status);
+  }
+  return res.json();
+}
+
+// ── Toast ──────────────────────────────────────────────────────────────
+function showToast(message, type) {
+  type = type || 'info';
+  var icons = { error: '⚠', success: '✓', info: 'ℹ' };
+  var container = document.getElementById('toast-container');
+  var toast = document.createElement('div');
+  toast.className = 'toast ' + type;
+  toast.innerHTML = '<span class="toast-icon">' + (icons[type] || '') + '</span>' + escHtml(message);
+  container.appendChild(toast);
+  setTimeout(function() {
+    toast.style.opacity = '0'; toast.style.transition = 'opacity 0.3s';
+    setTimeout(function() { toast.remove(); }, 300);
+  }, 3000);
+}
+
+// ── Init ───────────────────────────────────────────────────────────────
+async function init() {
+  renderTabs();
+  selectSource(LOG_SOURCES[0]);
+  document.addEventListener('keydown', handleKeyboard);
+}
+
+// ── Tab Rendering ──────────────────────────────────────────────────────
+function renderTabs() {
+  var container = document.getElementById('source-tabs');
+  var html = '';
+  for (var i = 0; i < LOG_SOURCES.length; i++) {
+    var src = LOG_SOURCES[i];
+    html += '<div class="source-tab" data-source="' + src.label +
+      '" onclick="selectSourceById(\'' + src.label + '\')" title="' +
+      escHtml(src.desc) + ' (' + src.key + ')">' +
+      '<span class="tab-key">' + escHtml(src.key) + '</span>' +
+      escHtml(src.label) +
+      '<span class="tab-desc">' + escHtml(src.desc) + '</span></div>';
+  }
+  container.innerHTML = html;
+}
+
+function updateTabHighlight() {
+  var tabs = document.querySelectorAll('.source-tab');
+  for (var i = 0; i < tabs.length; i++) {
+    var label = tabs[i].getAttribute('data-source');
+    tabs[i].classList.toggle('active', state.activeSource && state.activeSource.label === label);
+  }
+}
+
+// ── Source Selection ───────────────────────────────────────────────────
+function selectSourceById(label) {
+  var src = findSource(label);
+  if (src) selectSource(src);
+}
+
+function findSource(keyOrLabel) {
+  for (var i = 0; i < LOG_SOURCES.length; i++) {
+    if (LOG_SOURCES[i].key === keyOrLabel || LOG_SOURCES[i].label === keyOrLabel)
+      return LOG_SOURCES[i];
+  }
+  return null;
+}
+
+async function selectSource(src) {
+  stopPolling();
+  state.activeSource = src;
+  state.positions = {};
+  state.paused = false;
+  state.filterRegex = null;
+  state.filterPattern = '';
+  state.searchPattern = '';
+  state.searchMatches = [];
+  state.searchIdx = -1;
+  state.scrollFromBottom = 0;
+  if (src.label !== 'git') { state.gitDetail = false; state.gitLastHash = ''; }
+
+  updateTabHighlight();
+  clearLogDisplay();
+  updateStatusBar();
+
+  var sentinel = src.paths[0] || '';
+  if (sentinel === '__git__') {
+    state.pollInterval = 10000;
+    await fetchGitLog();
+  } else if (sentinel === '__rws__') {
+    state.pollInterval = 2000;
+    await fetchRwsTail();
+  } else {
+    state.pollInterval = 500;
+    await fetchLogTail();
+  }
+  startPolling();
+  document.getElementById('log-display').focus();
+}
+
+// ── Log Display ────────────────────────────────────────────────────────
+function clearLogDisplay() {
+  var display = document.getElementById('log-display');
+  display.innerHTML = '';
+  var anchor = document.createElement('div');
+  anchor.id = 'log-anchor';
+  anchor.style.height = '1px';
+  display.appendChild(anchor);
+}
+
+function getLogLines() {
+  return document.getElementById('log-display').querySelectorAll('.log-line');
+}
+
+function getVisibleLineCount() {
+  return Math.max(10, Math.floor(document.getElementById('log-display').clientHeight / 20));
+}
+
+// ── Colorization ───────────────────────────────────────────────────────
+var SEVERITY_RE = /\b(FATAL|ERROR|SEVERE|WARN|WARNING|INFO|DEBUG|TRACE)\b/gi;
+
+function colorizeLine(line, source) {
+  var sentinel = source.paths[0] || '';
+  if (sentinel === '__git__') return colorizeGitLine(line);
+  if (sentinel === '__rws__') return colorizeRwsLine(line);
+  if (/^────/.test(line)) return '<span class="git-header">' + escHtml(line) + '</span>';
+  return colorizeSeverity(line);
+}
+
+function colorizeSeverity(line) {
+  var html = escHtml(line);
+  SEVERITY_RE.lastIndex = 0;
+  return html.replace(SEVERITY_RE, function(match) {
+    var upper = match.toUpperCase();
+    if (upper === 'FATAL' || upper === 'ERROR' || upper === 'SEVERE')
+      return '<span class="sev-ERROR">' + match + '</span>';
+    if (upper === 'WARN' || upper === 'WARNING')
+      return '<span class="sev-WARN">' + match + '</span>';
+    if (upper === 'INFO')
+      return '<span class="sev-INFO">' + match + '</span>';
+    return '<span class="sev-DEBUG">' + match + '</span>';
+  });
+}
+
+function colorizeGitLine(line) {
+  var html = escHtml(line);
+  if (!line.trim()) return html;
+  if (state.gitDetail) {
+    if (/^commit\s/.test(line)) return '<span class="git-commit">' + html + '</span>';
+    if (/^Author:/.test(line)) return '<span class="git-author">' + html + '</span>';
+    if (/^Date:/.test(line)) return '<span class="git-date">' + html + '</span>';
+    if (/^    /.test(line)) return '<span class="git-message">' + html + '</span>';
+    return '<span class="sev-dim">' + html + '</span>';
+  }
+  if (line.indexOf('(HEAD') >= 0)
+    return '<span class="git-ref-head">' + html + '</span>';
+  if (line.indexOf('(tag:') >= 0)
+    return '<span class="git-ref-tag">' + html + '</span>';
+  if (line.indexOf('(origin') >= 0 || line.indexOf('(upstream') >= 0)
+    return '<span class="git-ref-remote">' + html + '</span>';
+  if (/^\s*\*/.test(line))
+    return '<span class="sev-INFO">' + html + '</span>';
+  return '<span class="git-graph">' + html + '</span>';
+}
+
+function colorizeRwsLine(line) {
+  var html = escHtml(line);
+  if (/!!!\s+ABORT/.test(line))
+    return '<span class="rws-abort">' + html + '</span>';
+  if (/<<<\s+STEP\s+\S+:\s+FAIL/.test(line))
+    return '<span class="rws-step-fail">' + html + '</span>';
+  if (/<<<\s+STEP\s+\S+:\s+PASS/.test(line))
+    return '<span class="rws-step-pass">' + html + '</span>';
+  if (/>>>\s+STEP\s+/.test(line))
+    return '<span class="rws-step-start">' + html + '</span>';
+  if (/·/.test(line) && (line.indexOf('running') >= 0 ||
+      line.indexOf('Checkpoints:') >= 0 || line.indexOf('step(s) completed') >= 0))
+    return '<span class="rws-progress">' + html + '</span>';
+  return colorizeSeverity(line);
+}
+
+// ── Append / DOM management ────────────────────────────────────────────
+function appendLines(lines, source) {
+  if (!lines || lines.length === 0) return;
+  var display = document.getElementById('log-display');
+  var wasAtBottom = isAtBottom();
+  var anchor = document.getElementById('log-anchor');
+  var fragment = document.createDocumentFragment();
+  for (var i = 0; i < lines.length; i++) {
+    var div = document.createElement('div');
+    div.className = 'log-line';
+    div.innerHTML = colorizeLine(lines[i], source);
+    fragment.appendChild(div);
+  }
+  if (anchor) display.insertBefore(fragment, anchor);
+  else display.appendChild(fragment);
+
+  if (state.filterRegex) applyFilterToDOM();
+  if (state.searchPattern) highlightSearchMatches();
+
+  var allLines = getLogLines();
+  while (allLines.length > state.maxLines) allLines[0].remove();
+
+  if (wasAtBottom && state.scrollFromBottom === 0 && !state.paused) scrollToBottom();
+  else if (state.scrollFromBottom > 0) state.scrollFromBottom += lines.length;
+
+  updateStatusBar();
+}
+
+function isAtBottom() {
+  var d = document.getElementById('log-display');
+  return d.scrollHeight - d.scrollTop - d.clientHeight < 50;
+}
+
+function scrollToBottom() {
+  var d = document.getElementById('log-display');
+  d.scrollTop = d.scrollHeight;
+  state.scrollFromBottom = 0;
+}
+
+function onLogScroll() {
+  if (state.paused) return;
+  if (isAtBottom()) { state.scrollFromBottom = 0; }
+  else {
+    var d = document.getElementById('log-display');
+    var dist = d.scrollHeight - d.scrollTop - d.clientHeight;
+    state.scrollFromBottom = Math.max(0, Math.floor(dist / 20));
+  }
+  updateStatusBar();
+}
+
+function scrollByLines(delta) {
+  var d = document.getElementById('log-display');
+  d.scrollTop = Math.max(0, Math.min(d.scrollHeight - d.clientHeight, d.scrollTop + delta * 20));
+  onLogScroll();
+}
+
+function scrollToLine(lineIdx) {
+  var d = document.getElementById('log-display');
+  d.scrollTop = Math.min(d.scrollHeight - d.clientHeight, Math.max(0, lineIdx * 20 - d.clientHeight / 3));
+  onLogScroll();
+}
+
+// ── Filter / Search ────────────────────────────────────────────────────
+function setFilter(pattern) {
+  pattern = (pattern || '').trim();
+  state.filterPattern = pattern;
+  state.searchPattern = pattern;
+  if (pattern) {
+    try { state.filterRegex = new RegExp(pattern, 'i'); }
+    catch(e) { state.filterRegex = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'); }
+  } else { state.filterRegex = null; }
+  state.searchMatches = [];
+  state.searchIdx = -1;
+  applyFilterToDOM();
+  updateSearchMatches();
+  if (pattern && state.searchMatches.length > 0) { state.searchIdx = 0; scrollToSearchMatch(); }
+  state.scrollFromBottom = 0;
+  updateStatusBar();
+}
+
+function applyFilterToDOM() {
+  var lines = getLogLines();
+  if (!state.filterRegex) {
+    for (var i = 0; i < lines.length; i++) lines[i].style.display = '';
+    return;
+  }
+  for (var i = 0; i < lines.length; i++)
+    lines[i].style.display = state.filterRegex.test(lines[i].textContent || '') ? '' : 'none';
+}
+
+function highlightSearchMatches() {
+  if (!state.searchPattern) return;
+  var lines = getLogLines();
+  try { var regex = new RegExp('(' + state.searchPattern + ')', 'gi'); }
+  catch(e) { return; }
+  for (var i = 0; i < lines.length; i++) {
+    if (lines[i].style.display === 'none') continue;
+    highlightInElement(lines[i], regex);
+  }
+}
+
+function highlightInElement(el, regex) {
+  regex.lastIndex = 0;
+  var walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null, false);
+  var textNodes = [];
+  while (walker.nextNode()) textNodes.push(walker.currentNode);
+  for (var t = 0; t < textNodes.length; t++) {
+    var node = textNodes[t];
+    var parent = node.parentNode;
+    if (parent.className && (parent.className.indexOf('search-match') >= 0 ||
+        parent.className.indexOf('search-current') >= 0)) continue;
+    var text = node.textContent;
+    regex.lastIndex = 0;
+    if (!regex.test(text)) continue;
+    regex.lastIndex = 0;
+    var frag = document.createDocumentFragment();
+    var lastIdx = 0, match;
+    while ((match = regex.exec(text)) !== null) {
+      if (match.index > lastIdx)
+        frag.appendChild(document.createTextNode(text.substring(lastIdx, match.index)));
+      var span = document.createElement('span');
+      span.className = 'search-match';
+      span.textContent = match[0];
+      frag.appendChild(span);
+      lastIdx = regex.lastIndex;
+      if (match[0] === '') regex.lastIndex++;
+    }
+    if (lastIdx < text.length)
+      frag.appendChild(document.createTextNode(text.substring(lastIdx)));
+    node.parentNode.replaceChild(frag, node);
+  }
+}
+
+function updateSearchMatches() {
+  state.searchMatches = [];
+  if (!state.searchPattern) { state.searchIdx = -1; return; }
+  var lines = getLogLines();
+  try { var regex = new RegExp(state.searchPattern, 'i'); } catch(e) { return; }
+  for (var i = 0; i < lines.length; i++) {
+    if (lines[i].style.display === 'none') continue;
+    if (regex.test(lines[i].textContent || '')) state.searchMatches.push(i);
+  }
+  if (state.searchIdx >= state.searchMatches.length)
+    state.searchIdx = state.searchMatches.length > 0 ? 0 : -1;
+}
+
+function scrollToSearchMatch() {
+  if (state.searchIdx < 0 || state.searchIdx >= state.searchMatches.length) return;
+  var matchLineIdx = state.searchMatches[state.searchIdx];
+  scrollToLine(matchLineIdx);
+  var lines = getLogLines();
+  for (var i = 0; i < lines.length; i++) {
+    var currents = lines[i].querySelectorAll('.search-current');
+    for (var s = 0; s < currents.length; s++) {
+      currents[s].classList.remove('search-current');
+      currents[s].classList.add('search-match');
+    }
+  }
+  if (matchLineIdx < lines.length) {
+    var matches = lines[matchLineIdx].querySelectorAll('.search-match');
+    for (var m = 0; m < matches.length; m++) {
+      matches[m].classList.remove('search-match');
+      matches[m].classList.add('search-current');
+    }
+  }
+}
+
+// ── Status Bar ─────────────────────────────────────────────────────────
+function updateStatusBar() {
+  var status = document.getElementById('log-status');
+  var lines = getLogLines();
+  var total = lines.length;
+  var visibleH = getVisibleLineCount();
+  var visibleStart = Math.max(0, total - visibleH - state.scrollFromBottom);
+  var pct = total > 0 ? Math.round(Math.min(visibleStart + visibleH, total) * 100 / total) : 0;
+
+  var parts = [];
+  parts.push('L: ' + (visibleStart + 1) + '-' + Math.min(visibleStart + visibleH, total) + '/' + total + ' (' + pct + '%)');
+
+  if (state.filterPattern) {
+    parts.push('| <span class="status-badge filtered">/' + escHtml(state.filterPattern) + '/</span>');
+    if (state.searchMatches.length > 0)
+      parts.push('match ' + (state.searchIdx + 1) + '/' + state.searchMatches.length);
+  }
+
+  if (state.paused)
+    parts.push('<span class="status-badge paused">PAUSED</span>');
+  else if (state.scrollFromBottom > 0)
+    parts.push('<span class="status-badge paused">↥ SCROLLED</span>');
+  else
+    parts.push('<span class="status-badge live">LIVE</span>');
+
+  parts.push('<span style="opacity:0.5;">' + (state.activeSource ? state.activeSource.label : '—') + '</span>');
+  status.innerHTML = parts.join(' ');
+}
+
+// ── Data Fetching ──────────────────────────────────────────────────────
+async function fetchLogTail() {
+  try {
+    var data = await apiPost('/api/logs/tail', { source: state.activeSource.label, lines: 200 });
+    if (data.positions) state.positions = data.positions;
+    if (data.lines && data.lines.length > 0) appendLines(data.lines, state.activeSource);
+  } catch(e) { showToast('Failed to load logs: ' + e.message, 'error'); }
+}
+
+async function pollForUpdates() {
+  if (state.paused || !state.activeSource) return;
+  var sentinel = state.activeSource.paths[0] || '';
+  try {
+    if (sentinel === '__git__') { await fetchGitLog(); }
+    else if (sentinel === '__rws__') { await pollRwsUpdates(); }
+    else {
+      var data = await apiPost('/api/logs/poll', { source: state.activeSource.label, positions: state.positions });
+      if (data.positions) state.positions = data.positions;
+      if (data.lines && data.lines.length > 0) appendLines(data.lines, state.activeSource);
+    }
+  } catch(e) {}
+}
+
+async function fetchGitLog() {
+  try {
+    var n = 50;
+    var data = await apiGet('/api/logs/git?lines=' + n + '&detail=' + (state.gitDetail ? '1' : '0'));
+    if (data.lines && data.lines.length > 0) {
+      if (data.lines[0] === state.gitLastHash) return;
+      state.gitLastHash = data.lines[0];
+      var display = document.getElementById('log-display');
+      display.innerHTML = '';
+      var anchor = document.createElement('div');
+      anchor.id = 'log-anchor'; anchor.style.height = '1px';
+      display.appendChild(anchor);
+      state.scrollFromBottom = 0;
+      appendLines(['', data.header], state.activeSource);
+      appendLines(data.lines, state.activeSource);
+    }
+  } catch(e) {}
+}
+
+async function fetchRwsTail() {
+  try {
+    var data = await apiPost('/api/logs/tail', { source: 'rws', lines: 200 });
+    if (data.positions) state.positions = data.positions;
+    if (data.lines && data.lines.length > 0) appendLines(data.lines, state.activeSource);
+    else appendLines(['(waiting for RWS output — run a test to see results)'], state.activeSource);
+  } catch(e) {
+    appendLines(['(waiting for RWS output — run a test to see results)'], state.activeSource);
+  }
+}
+
+async function pollRwsUpdates() {
+  try {
+    var data = await apiPost('/api/logs/poll', { source: 'rws', positions: state.positions });
+    if (data.positions) {
+      for (var key in data.positions) state.positions[key] = data.positions[key];
+    }
+    if (data.lines && data.lines.length > 0) appendLines(data.lines, state.activeSource);
+  } catch(e) {}
+}
+
+// ── Polling Loop ───────────────────────────────────────────────────────
+function startPolling() { stopPolling(); schedulePoll(); }
+function stopPolling() {
+  if (state.pollTimer) { clearTimeout(state.pollTimer); state.pollTimer = null; }
+}
+function schedulePoll() {
+  state.pollTimer = setTimeout(function() {
+    pollForUpdates().then(function() { schedulePoll(); });
+  }, state.pollInterval);
+}
+
+// ── Actions ────────────────────────────────────────────────────────────
+function actionTogglePause() {
+  state.paused = !state.paused;
+  if (!state.paused) { state.scrollFromBottom = 0; scrollToBottom(); pollForUpdates(); }
+  updateStatusBar();
+  showToast((state.activeSource ? state.activeSource.label : 'log') + ': ' +
+    (state.paused ? 'PAUSED' : 'LIVE'), state.paused ? 'info' : 'success');
+}
+
+function actionClear() {
+  clearLogDisplay();
+  state.positions = {};
+  state.gitLastHash = '';
+  state.searchMatches = [];
+  state.searchIdx = -1;
+  state.scrollFromBottom = 0;
+  updateStatusBar();
+}
+
+function actionCopy() {
+  var lines = getLogLines();
+  var text = '';
+  for (var i = 0; i < lines.length; i++) text += (lines[i].textContent || '') + '\n';
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(function() {
+      showToast('Copied ' + lines.length + ' lines to clipboard', 'success');
+    }).catch(function() { showToast('Failed to copy to clipboard', 'error'); });
+  } else {
+    var ta = document.createElement('textarea');
+    ta.value = text; ta.style.position = 'fixed'; ta.style.left = '-9999px';
+    document.body.appendChild(ta); ta.select();
+    try { document.execCommand('copy'); showToast('Copied ' + lines.length + ' lines to clipboard', 'success'); }
+    catch(e) { showToast('Failed to copy to clipboard', 'error'); }
+    document.body.removeChild(ta);
+  }
+}
+
+function actionScrollUp() { scrollByLines(1); }
+function actionScrollDown() { scrollByLines(-1); }
+function actionScrollPageUp() { scrollByLines(getVisibleLineCount() - 2); }
+function actionScrollPageDown() { scrollByLines(-(getVisibleLineCount() - 2)); }
+function actionScrollHome() { document.getElementById('log-display').scrollTop = 0; onLogScroll(); }
+function actionScrollEnd() { scrollToBottom(); updateStatusBar(); }
+
+function actionSearchNext() {
+  updateSearchMatches();
+  if (state.searchMatches.length === 0) return;
+  state.searchIdx = (state.searchIdx + 1) % state.searchMatches.length;
+  scrollToSearchMatch();
+  updateStatusBar();
+}
+
+function actionSearchPrev() {
+  updateSearchMatches();
+  if (state.searchMatches.length === 0) return;
+  state.searchIdx = (state.searchIdx - 1 + state.searchMatches.length) % state.searchMatches.length;
+  scrollToSearchMatch();
+  updateStatusBar();
+}
+
+function actionShowFilter() {
+  var bar = document.getElementById('filter-bar');
+  var input = document.getElementById('filter-input');
+  bar.style.display = 'flex';
+  input.value = state.filterPattern || '';
+  input.focus();
+  input.select();
+}
+
+function actionClearFilter() {
+  document.getElementById('filter-bar').style.display = 'none';
+  document.getElementById('filter-input').value = '';
+  setFilter('');
+  var lines = getLogLines();
+  for (var i = 0; i < lines.length; i++) lines[i].style.display = '';
+  document.getElementById('filter-count').textContent = '';
+  updateStatusBar();
+  scrollToBottom();
+  document.getElementById('log-display').focus();
+}
+
+function actionToggleGitDetail() {
+  if (!state.activeSource || state.activeSource.label !== 'git') return;
+  state.gitDetail = !state.gitDetail;
+  state.gitLastHash = '';
+  clearLogDisplay();
+  fetchGitLog();
+  showToast('Git log: ' + (state.gitDetail ? 'detail' : 'compact'), 'info');
+}
+
+// ── Keyboard Handling ──────────────────────────────────────────────────
+function handleKeyboard(e) {
+  if (e.target.id === 'filter-input') {
+    if (e.key === 'Escape') { actionClearFilter(); e.preventDefault(); }
+    if (e.key === 'F3') { if (e.shiftKey) actionSearchPrev(); else actionSearchNext(); e.preventDefault(); }
+    return;
+  }
+  var tag = e.target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+
+  var key = e.key;
+  var handled = true;
+
+  if (key >= '0' && key <= '9') {
+    var src = LOG_SOURCES.find(function(s) { return s.key === key; });
+    if (src) selectSource(src);
+    e.preventDefault(); return;
+  }
+  if (key === 'r' || key === 'R') {
+    if (!state.activeSource || state.activeSource.label !== 'rws') {
+      var rwsSrc = findSource('rws'); if (rwsSrc) selectSource(rwsSrc);
+    }
+    e.preventDefault(); return;
+  }
+  if (key === 'g' || key === 'G') {
+    if (state.activeSource && state.activeSource.label === 'git') actionToggleGitDetail();
+    else { var gitSrc = findSource('git'); if (gitSrc) selectSource(gitSrc); }
+    e.preventDefault(); return;
+  }
+
+  switch (key) {
+    case 'ArrowUp': actionScrollUp(); break;
+    case 'ArrowDown': actionScrollDown(); break;
+    case 'PageUp': actionScrollPageUp(); break;
+    case 'PageDown': actionScrollPageDown(); break;
+    case 'Home': actionScrollHome(); break;
+    case 'End': actionScrollEnd(); break;
+    case ' ':
+      if (!e.ctrlKey && !e.metaKey) actionTogglePause();
+      else handled = false;
+      break;
+    case 'c': case 'C':
+      if (!e.ctrlKey && !e.metaKey) actionClear(); else handled = false;
+      break;
+    case 'y': case 'Y':
+      if (!e.ctrlKey && !e.metaKey) actionCopy(); else handled = false;
+      break;
+    case '/':
+      if (!e.ctrlKey) actionShowFilter(); else handled = false;
+      break;
+    case 'Escape':
+      if (document.getElementById('filter-bar').style.display !== 'none') actionClearFilter();
+      else handled = false;
+      break;
+    case 'F3':
+      if (e.shiftKey) actionSearchPrev(); else actionSearchNext();
+      break;
+    default: handled = false;
+  }
+  if (e.ctrlKey && !e.metaKey && (key === 'f' || key === 'F')) { actionShowFilter(); handled = true; }
+  if (handled) e.preventDefault();
+}
+
+// ── Filter input events ────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', function() {
+  var fi = document.getElementById('filter-input');
+  fi.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') {
+      setFilter(fi.value);
+      document.getElementById('filter-count').textContent =
+        state.searchMatches.length > 0 ? state.searchMatches.length + ' matches' :
+        (state.filterPattern ? '0 matches' : '');
+      document.getElementById('log-display').focus();
+      e.preventDefault();
+    }
+  });
+
+  // Attach scroll listener
+  document.getElementById('log-display').addEventListener('scroll', onLogScroll);
+});
+
+// ── Escape helpers ─────────────────────────────────────────────────────
+function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+// ── Start ──────────────────────────────────────────────────────────────
+init();
+</script>
+</body>
+</html>

--- a/coworker/gui/frontend/watch-logs.html
+++ b/coworker/gui/frontend/watch-logs.html
@@ -161,7 +161,7 @@ body {
   border-bottom: 1px solid var(--border);
   padding: 5px 0.75rem;
   flex-shrink: 0;
-  display: inline-flex; align-items: stretch; gap: 6px;
+  display: inline-flex; align-items: stretch; gap: 8px;
   box-shadow: var(--shadow-sm);
 }
 .source-dropdown { position: relative; }

--- a/coworker/gui/frontend/watch-logs.html
+++ b/coworker/gui/frontend/watch-logs.html
@@ -161,7 +161,7 @@ body {
   border-bottom: 1px solid var(--border);
   padding: 5px 0.75rem;
   flex-shrink: 0;
-  display: inline-flex; align-items: stretch; gap: 8px;
+  display: inline-flex; align-items: stretch; gap: 4px;
   box-shadow: var(--shadow-sm);
 }
 .source-dropdown { position: relative; }

--- a/coworker/gui/frontend/watch-logs.html
+++ b/coworker/gui/frontend/watch-logs.html
@@ -161,7 +161,7 @@ body {
   border-bottom: 1px solid var(--border);
   padding: 5px 0.75rem;
   flex-shrink: 0;
-  display: flex; align-items: stretch; gap: 6px;
+  display: inline-flex; align-items: stretch; gap: 6px;
   box-shadow: var(--shadow-sm);
 }
 .source-dropdown { position: relative; }

--- a/coworker/gui/frontend/watch-logs.html
+++ b/coworker/gui/frontend/watch-logs.html
@@ -161,24 +161,18 @@ body {
   border-bottom: 1px solid var(--border);
   padding: 5px 0.75rem;
   flex-shrink: 0;
-  display: flex; align-items: stretch;
+  display: flex; align-items: stretch; gap: 6px;
   box-shadow: var(--shadow-sm);
 }
-.source-dropdown { position: relative; flex: 1; }
-.source-dropdown + .source-dropdown { margin-left: -1px; }
-.source-dropdown:first-child .source-dropdown-btn { border-radius: var(--radius-sm) 0 0 var(--radius-sm); }
-.source-dropdown:last-child  .source-dropdown-btn { border-radius: 0 var(--radius-sm) var(--radius-sm) 0; }
-.source-dropdown:first-child:last-child .source-dropdown-btn { border-radius: var(--radius-sm); }
+.source-dropdown { position: relative; }
 .source-dropdown-btn {
-  display: flex; align-items: center; justify-content: center;
-  width: 100%; height: 100%; gap: 5px;
+  display: flex; align-items: center; gap: 5px;
   padding: 6px 10px;
   font-size: 0.72rem; font-weight: 500;
   cursor: pointer; user-select: none;
   border: 1px solid var(--border);
   background: var(--bg-raised); color: var(--text-secondary);
   transition: all var(--transition);
-  position: relative; z-index: 1;
 }
 .source-dropdown.open .source-dropdown-btn { z-index: 201; }
 .source-dropdown-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
@@ -208,7 +202,7 @@ body {
 .source-dropdown.open .source-dropdown-btn .group-name { color: var(--accent); }
 .source-dropdown.open .source-dropdown-btn .cur-source { color: var(--text-primary); }
 .source-dropdown-menu {
-  display: none; position: absolute; top: 100%; left: 0; right: 0;
+  display: none; position: absolute; top: 100%; left: 0; min-width: 100%;
   margin-top: -1px;
   background: var(--bg-surface);
   border: 1px solid var(--accent);

--- a/coworker/gui/frontend/watch-logs.html
+++ b/coworker/gui/frontend/watch-logs.html
@@ -154,51 +154,68 @@ body {
 .theme-toggle:hover { background: rgba(255,255,255,0.15); border-color: rgba(255,255,255,0.25); }
 
 /* ═══════════════════════════════════════════════════════════════════════
-   Source Tabs
+   Source Dropdowns
    ═══════════════════════════════════════════════════════════════════════ */
 .source-tabs {
   background: var(--bg-surface);
   border-bottom: 1px solid var(--border);
   padding: 4px 0.75rem;
   flex-shrink: 0;
-  display: flex; align-items: center; gap: 2px;
-  overflow-x: auto; white-space: nowrap;
+  display: flex; align-items: center; gap: 6px;
   box-shadow: var(--shadow-sm);
 }
-.source-tab {
-  display: inline-flex; align-items: center; gap: 4px;
-  padding: 4px 8px;
-  font-size: 0.7rem; font-weight: 500;
+.source-dropdown { position: relative; flex-shrink: 0; }
+.source-dropdown-btn {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 5px 10px;
+  font-size: 0.72rem; font-weight: 500;
   cursor: pointer; user-select: none;
-  border: 1px solid transparent;
-  background: transparent; color: var(--text-secondary);
+  border: 1px solid var(--border);
+  background: var(--bg-raised); color: var(--text-secondary);
   border-radius: var(--radius-sm);
   transition: all var(--transition);
-  flex-shrink: 0;
 }
-.source-tab:hover { color: var(--text-primary); background: var(--bg-hover); }
-.source-tab.active {
-  color: var(--text-on-dark);
-  background: var(--accent);
-  border-color: var(--accent);
+.source-dropdown-btn:hover { color: var(--text-primary); border-color: var(--text-muted); }
+.source-dropdown-btn .arrow {
+  font-size: 0.5rem; transition: transform var(--transition);
+  opacity: 0.5; margin-left: -1px;
 }
-.source-tab .tab-key {
+.source-dropdown.open .source-dropdown-btn { border-color: var(--accent); color: var(--text-primary); }
+.source-dropdown.open .source-dropdown-btn .arrow { transform: rotate(180deg); opacity: 1; }
+.source-dropdown-btn .cur-key {
   font-size: 0.58rem; font-weight: 700;
-  background: rgba(0,0,0,0.12); color: inherit;
+  background: var(--accent-bg); color: var(--accent);
   border-radius: 3px; padding: 0px 4px; min-width: 16px;
   text-align: center; line-height: 1.6;
-  opacity: 0.7;
 }
-.source-tab.active .tab-key { background: rgba(255,255,255,0.2); opacity: 1; }
-.source-group-label {
-  font-size: 0.58rem; font-weight: 600;
-  color: var(--text-muted); letter-spacing: 0.05em;
-  padding: 2px 6px 2px 10px; text-transform: uppercase;
-  flex-shrink: 0; user-select: none;
-  border-left: 2px solid var(--border);
-  margin-left: 6px; line-height: 1.3;
+.source-dropdown-menu {
+  display: none; position: absolute; top: 100%; left: 0;
+  margin-top: 2px; min-width: 170px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
+  z-index: 200; padding: 3px 0;
 }
-.source-group-label:first-child { border-left: none; margin-left: 0; padding-left: 2px; }
+.source-dropdown.open .source-dropdown-menu { display: block; }
+.source-dropdown-item {
+  display: flex; align-items: center; gap: 6px;
+  padding: 5px 12px; cursor: pointer;
+  font-size: 0.73rem; color: var(--text-primary);
+  transition: background 0.1s;
+}
+.source-dropdown-item:hover { background: var(--bg-hover); }
+.source-dropdown-item.active { background: var(--bg-selected); color: var(--accent); font-weight: 600; }
+.source-dropdown-item .item-key {
+  font-size: 0.6rem; font-weight: 700;
+  background: var(--bg-inset); color: var(--text-muted);
+  border-radius: 3px; padding: 0px 4px; min-width: 16px;
+  text-align: center; line-height: 1.6;
+}
+.source-dropdown-item.active .item-key { background: var(--accent-bg); color: var(--accent); }
+.source-dropdown-item .item-desc {
+  font-size: 0.62rem; color: var(--text-muted); margin-left: auto;
+}
 /* ═══════════════════════════════════════════════════════════════════════
    Main Log Display
    ═══════════════════════════════════════════════════════════════════════ */
@@ -328,8 +345,8 @@ body {
    Responsive
    ═══════════════════════════════════════════════════════════════════════ */
 @media (max-width: 768px) {
-  .source-tabs { padding: 3px 0.5rem; }
-  .source-tab { padding: 3px 6px; font-size: 0.65rem; }
+  .source-tabs { padding: 3px 0.5rem; gap: 4px; }
+  .source-dropdown-btn { padding: 4px 8px; font-size: 0.68rem; }
   .log-display { font-size: 0.7rem; }
 }
 </style>
@@ -356,7 +373,7 @@ body {
 
 <!-- ═══════ SOURCE TABS ═══════ -->
 <nav class="source-tabs" id="source-tabs">
-  <!-- Populated by JS -->
+  <!-- Populated by JS — dropdown groups -->
 </nav>
 
 <!-- ═══════ LOG VIEWER ═══════ -->
@@ -492,31 +509,63 @@ var SOURCE_GROUPS = [
 
 function renderTabs() {
   var container = document.getElementById('source-tabs');
+  var activeLabel = state.activeSource ? state.activeSource.label : null;
   var html = '';
-  var lastGroup = '';
-  for (var i = 0; i < LOG_SOURCES.length; i++) {
-    var src = LOG_SOURCES[i];
-    // Emit group label when group changes
-    if (src.group !== lastGroup) {
-      var g = SOURCE_GROUPS.find(function(g) { return g.id === src.group; });
-      if (g) html += '<span class="source-group-label">' + escHtml(g.label) + '</span>';
-      lastGroup = src.group;
+  for (var g = 0; g < SOURCE_GROUPS.length; g++) {
+    var group = SOURCE_GROUPS[g];
+    var members = LOG_SOURCES.filter(function(s) { return s.group === group.id; });
+    var activeMember = members.find(function(s) { return s.label === activeLabel; });
+    var curLabel = activeMember ? activeMember.label : group.label;
+    var curKey = activeMember ? activeMember.key : '';
+
+    html += '<div class="source-dropdown" data-group="' + group.id + '">';
+    html += '<div class="source-dropdown-btn" onclick="toggleDropdown(\'' + group.id + '\', event)">';
+    html += escHtml(group.label);
+    if (curKey) html += '<span class="cur-key">' + escHtml(curKey) + '</span>';
+    html += '<span class="arrow">▾</span>';
+    html += '</div>';
+    html += '<div class="source-dropdown-menu">';
+    for (var m = 0; m < members.length; m++) {
+      var src = members[m];
+      var activeClass = (src.label === activeLabel) ? ' active' : '';
+      html += '<div class="source-dropdown-item' + activeClass + '" data-source="' + src.label +
+        '" onclick="selectSourceById(\'' + src.label + '\'); closeAllDropdowns();">' +
+        '<span class="item-key">' + escHtml(src.key) + '</span>' +
+        escHtml(src.label) +
+        '<span class="item-desc">' + escHtml(src.desc) + '</span></div>';
     }
-    html += '<div class="source-tab" data-source="' + src.label +
-      '" onclick="selectSourceById(\'' + src.label + '\')" title="' +
-      escHtml(src.desc) + ' (' + src.key + ')">' +
-      '<span class="tab-key">' + escHtml(src.key) + '</span>' +
-      escHtml(src.label) + '</div>';
+    html += '</div></div>';
   }
   container.innerHTML = html;
 }
 
-function updateTabHighlight() {
-  var tabs = document.querySelectorAll('.source-tab');
-  for (var i = 0; i < tabs.length; i++) {
-    var label = tabs[i].getAttribute('data-source');
-    tabs[i].classList.toggle('active', state.activeSource && state.activeSource.label === label);
+var openDropdown = null;
+
+function toggleDropdown(groupId, event) {
+  event.stopPropagation();
+  var dropdown = document.querySelector('.source-dropdown[data-group="' + groupId + '"]');
+  if (!dropdown) return;
+  var wasOpen = dropdown.classList.contains('open');
+  closeAllDropdowns();
+  if (!wasOpen) {
+    dropdown.classList.add('open');
+    openDropdown = groupId;
   }
+}
+
+function closeAllDropdowns() {
+  var all = document.querySelectorAll('.source-dropdown.open');
+  for (var i = 0; i < all.length; i++) all[i].classList.remove('open');
+  openDropdown = null;
+}
+
+// Close dropdowns when clicking outside
+document.addEventListener('click', function(e) {
+  if (!e.target.closest('.source-dropdown')) closeAllDropdowns();
+});
+
+function updateTabHighlight() {
+  renderTabs(); // simpler to re-render since it's just 3 dropdowns
 }
 
 // ── Source Selection ───────────────────────────────────────────────────

--- a/coworker/gui/frontend/watch-logs.html
+++ b/coworker/gui/frontend/watch-logs.html
@@ -339,7 +339,7 @@ body {
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>
     </svg>
-    <h1>Browser4 Log Dashboard</h1>
+    <h1>Log Dashboard</h1>
   </div>
   <div class="header-right">
     <nav class="header-nav">

--- a/coworker/gui/frontend/watch-logs.html
+++ b/coworker/gui/frontend/watch-logs.html
@@ -161,12 +161,13 @@ body {
   border-bottom: 1px solid var(--border);
   padding: 4px 0.75rem;
   flex-shrink: 0;
-  display: flex; align-items: center; gap: 6px;
+  display: flex; align-items: center; gap: 5px;
   box-shadow: var(--shadow-sm);
 }
-.source-dropdown { position: relative; flex-shrink: 0; }
+.source-dropdown { position: relative; flex: 1; }
 .source-dropdown-btn {
-  display: inline-flex; align-items: center; gap: 5px;
+  display: flex; align-items: center; justify-content: space-between;
+  width: 100%; gap: 5px;
   padding: 5px 10px;
   font-size: 0.72rem; font-weight: 500;
   cursor: pointer; user-select: none;

--- a/coworker/gui/frontend/watch-logs.html
+++ b/coworker/gui/frontend/watch-logs.html
@@ -161,12 +161,15 @@ body {
   border-bottom: 1px solid var(--border);
   padding: 5px 0.75rem;
   flex-shrink: 0;
-  display: inline-flex; align-items: stretch; gap: 4px;
+  display: flex; align-items: stretch; gap: 6px;
+  align-self: flex-start;
   box-shadow: var(--shadow-sm);
+  border-radius: var(--radius-sm);
 }
 .source-dropdown { position: relative; }
 .source-dropdown-btn {
   display: flex; align-items: center; gap: 5px;
+  white-space: nowrap;
   padding: 6px 10px;
   font-size: 0.72rem; font-weight: 500;
   cursor: pointer; user-select: none;

--- a/coworker/gui/frontend/watch-logs.html
+++ b/coworker/gui/frontend/watch-logs.html
@@ -159,64 +159,94 @@ body {
 .source-tabs {
   background: var(--bg-surface);
   border-bottom: 1px solid var(--border);
-  padding: 4px 0.75rem;
+  padding: 5px 0.75rem;
   flex-shrink: 0;
-  display: flex; align-items: center; gap: 5px;
+  display: flex; align-items: stretch;
   box-shadow: var(--shadow-sm);
 }
 .source-dropdown { position: relative; flex: 1; }
+.source-dropdown + .source-dropdown { margin-left: -1px; }
+.source-dropdown:first-child .source-dropdown-btn { border-radius: var(--radius-sm) 0 0 var(--radius-sm); }
+.source-dropdown:last-child  .source-dropdown-btn { border-radius: 0 var(--radius-sm) var(--radius-sm) 0; }
+.source-dropdown:first-child:last-child .source-dropdown-btn { border-radius: var(--radius-sm); }
 .source-dropdown-btn {
-  display: flex; align-items: center; justify-content: space-between;
-  width: 100%; gap: 5px;
-  padding: 5px 10px;
+  display: flex; align-items: center; justify-content: center;
+  width: 100%; height: 100%; gap: 5px;
+  padding: 6px 10px;
   font-size: 0.72rem; font-weight: 500;
   cursor: pointer; user-select: none;
   border: 1px solid var(--border);
   background: var(--bg-raised); color: var(--text-secondary);
-  border-radius: var(--radius-sm);
   transition: all var(--transition);
+  position: relative; z-index: 1;
 }
-.source-dropdown-btn:hover { color: var(--text-primary); border-color: var(--text-muted); }
+.source-dropdown.open .source-dropdown-btn { z-index: 201; }
+.source-dropdown-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+.source-dropdown.open .source-dropdown-btn {
+  border-color: var(--accent); color: var(--text-primary);
+  background: var(--bg-surface);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+}
 .source-dropdown-btn .arrow {
   font-size: 0.5rem; transition: transform var(--transition);
-  opacity: 0.5; margin-left: -1px;
+  opacity: 0.4; flex-shrink: 0;
 }
-.source-dropdown.open .source-dropdown-btn { border-color: var(--accent); color: var(--text-primary); }
-.source-dropdown.open .source-dropdown-btn .arrow { transform: rotate(180deg); opacity: 1; }
-.source-dropdown-btn .cur-key {
-  font-size: 0.58rem; font-weight: 700;
-  background: var(--accent-bg); color: var(--accent);
-  border-radius: 3px; padding: 0px 4px; min-width: 16px;
-  text-align: center; line-height: 1.6;
+.source-dropdown.open .source-dropdown-btn .arrow { transform: rotate(180deg); opacity: 0.8; }
+.source-dropdown-btn .group-name {
+  font-weight: 500; color: var(--text-muted); font-size: 0.65rem;
+  text-transform: uppercase; letter-spacing: 0.04em;
 }
+.source-dropdown-btn .sep {
+  color: var(--border); font-weight: 300;
+}
+.source-dropdown-btn .cur-source {
+  font-weight: 500; color: var(--text-secondary);
+}
+.source-dropdown-btn .cur-label {
+  font-weight: 600; color: var(--accent);
+}
+.source-dropdown.open .source-dropdown-btn .group-name { color: var(--accent); }
+.source-dropdown.open .source-dropdown-btn .cur-source { color: var(--text-primary); }
 .source-dropdown-menu {
-  display: none; position: absolute; top: 100%; left: 0;
-  margin-top: 2px; min-width: 170px;
+  display: none; position: absolute; top: 100%; left: 0; right: 0;
+  margin-top: -1px;
   background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-md);
-  z-index: 200; padding: 3px 0;
+  border: 1px solid var(--accent);
+  border-top: none;
+  border-radius: 0 0 var(--radius) var(--radius);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.12);
+  z-index: 200; padding: 4px 0;
+  overflow: hidden;
 }
 .source-dropdown.open .source-dropdown-menu { display: block; }
 .source-dropdown-item {
-  display: flex; align-items: center; gap: 6px;
-  padding: 5px 12px; cursor: pointer;
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 12px; cursor: pointer;
   font-size: 0.73rem; color: var(--text-primary);
   transition: background 0.1s;
 }
 .source-dropdown-item:hover { background: var(--bg-hover); }
-.source-dropdown-item.active { background: var(--bg-selected); color: var(--accent); font-weight: 600; }
+.source-dropdown-item.active {
+  background: var(--bg-selected);
+  box-shadow: inset 3px 0 0 var(--accent);
+}
 .source-dropdown-item .item-key {
   font-size: 0.6rem; font-weight: 700;
   background: var(--bg-inset); color: var(--text-muted);
   border-radius: 3px; padding: 0px 4px; min-width: 16px;
-  text-align: center; line-height: 1.6;
+  text-align: center; line-height: 1.6; flex-shrink: 0;
 }
 .source-dropdown-item.active .item-key { background: var(--accent-bg); color: var(--accent); }
 .source-dropdown-item .item-desc {
   font-size: 0.62rem; color: var(--text-muted); margin-left: auto;
+  white-space: nowrap;
 }
+.source-dropdown-item .item-check {
+  margin-left: auto; color: var(--accent); font-weight: 700;
+  font-size: 0.7rem; display: none;
+}
+.source-dropdown-item.active .item-check { display: inline; }
+.source-dropdown-item.active .item-desc { display: none; }
 /* ═══════════════════════════════════════════════════════════════════════
    Main Log Display
    ═══════════════════════════════════════════════════════════════════════ */
@@ -347,7 +377,9 @@ body {
    ═══════════════════════════════════════════════════════════════════════ */
 @media (max-width: 768px) {
   .source-tabs { padding: 3px 0.5rem; gap: 4px; }
-  .source-dropdown-btn { padding: 4px 8px; font-size: 0.68rem; }
+  .source-dropdown-btn { padding: 4px 8px; font-size: 0.66rem; }
+  .source-dropdown-btn .group-name { display: none; }
+  .source-dropdown-btn .sep { display: none; }
   .log-display { font-size: 0.7rem; }
 }
 </style>
@@ -516,13 +548,14 @@ function renderTabs() {
     var group = SOURCE_GROUPS[g];
     var members = LOG_SOURCES.filter(function(s) { return s.group === group.id; });
     var activeMember = members.find(function(s) { return s.label === activeLabel; });
-    var curLabel = activeMember ? activeMember.label : group.label;
-    var curKey = activeMember ? activeMember.key : '';
+    var btnLabel = activeMember ? escHtml(activeMember.label) : escHtml(group.label);
+    var btnClass = activeMember ? ' cur-label' : '';
 
     html += '<div class="source-dropdown" data-group="' + group.id + '">';
-    html += '<div class="source-dropdown-btn" onclick="toggleDropdown(\'' + group.id + '\', event)">';
-    html += escHtml(group.label);
-    if (curKey) html += '<span class="cur-key">' + escHtml(curKey) + '</span>';
+    html += '<div class="source-dropdown-btn" data-group="' + group.id + '">';
+    html += '<span class="group-name">' + escHtml(group.label) + '</span>';
+    html += '<span class="sep">·</span>';
+    html += '<span class="cur-source' + btnClass + '">' + btnLabel + '</span>';
     html += '<span class="arrow">▾</span>';
     html += '</div>';
     html += '<div class="source-dropdown-menu">';
@@ -530,20 +563,58 @@ function renderTabs() {
       var src = members[m];
       var activeClass = (src.label === activeLabel) ? ' active' : '';
       html += '<div class="source-dropdown-item' + activeClass + '" data-source="' + src.label +
-        '" onclick="selectSourceById(\'' + src.label + '\'); closeAllDropdowns();">' +
+        '" data-group="' + group.id + '">' +
         '<span class="item-key">' + escHtml(src.key) + '</span>' +
-        escHtml(src.label) +
-        '<span class="item-desc">' + escHtml(src.desc) + '</span></div>';
+        '<span>' + escHtml(src.label) + '</span>' +
+        '<span class="item-desc">' + escHtml(src.desc) + '</span>' +
+        '<span class="item-check">✓</span></div>';
     }
     html += '</div></div>';
   }
   container.innerHTML = html;
+
+  // Re-bind click handlers
+  bindDropdownEvents();
+}
+
+function bindDropdownEvents() {
+  // Button click toggles
+  var btns = document.querySelectorAll('.source-dropdown-btn');
+  for (var i = 0; i < btns.length; i++) {
+    btns[i].addEventListener('click', function(e) {
+      e.stopPropagation();
+      var groupId = this.getAttribute('data-group');
+      toggleDropdown(groupId);
+    });
+  }
+
+  // Item click selects source
+  var items = document.querySelectorAll('.source-dropdown-item');
+  for (var j = 0; j < items.length; j++) {
+    items[j].addEventListener('click', function(e) {
+      e.stopPropagation();
+      var label = this.getAttribute('data-source');
+      selectSourceById(label);
+      closeAllDropdowns();
+    });
+  }
+
+  // Hover over button when another dropdown is open → switch to this one
+  for (var k = 0; k < btns.length; k++) {
+    btns[k].addEventListener('mouseenter', function() {
+      if (openDropdown && openDropdown !== this.getAttribute('data-group')) {
+        closeAllDropdowns();
+        var gid = this.getAttribute('data-group');
+        var dd = document.querySelector('.source-dropdown[data-group="' + gid + '"]');
+        if (dd) { dd.classList.add('open'); openDropdown = gid; }
+      }
+    });
+  }
 }
 
 var openDropdown = null;
 
-function toggleDropdown(groupId, event) {
-  event.stopPropagation();
+function toggleDropdown(groupId) {
   var dropdown = document.querySelector('.source-dropdown[data-group="' + groupId + '"]');
   if (!dropdown) return;
   var wasOpen = dropdown.classList.contains('open');

--- a/coworker/gui/frontend/watch-logs.html
+++ b/coworker/gui/frontend/watch-logs.html
@@ -190,6 +190,15 @@ body {
   opacity: 0.7;
 }
 .source-tab.active .tab-key { background: rgba(255,255,255,0.2); opacity: 1; }
+.source-group-label {
+  font-size: 0.58rem; font-weight: 600;
+  color: var(--text-muted); letter-spacing: 0.05em;
+  padding: 2px 6px 2px 10px; text-transform: uppercase;
+  flex-shrink: 0; user-select: none;
+  border-left: 2px solid var(--border);
+  margin-left: 6px; line-height: 1.3;
+}
+.source-group-label:first-child { border-left: none; margin-left: 0; padding-left: 2px; }
 /* ═══════════════════════════════════════════════════════════════════════
    Main Log Display
    ═══════════════════════════════════════════════════════════════════════ */
@@ -398,17 +407,17 @@ function toggleTheme() {
 
 // ── Log Source Definitions ─────────────────────────────────────────────
 var LOG_SOURCES = [
-  { key: "1", label: "pulsar",  desc: "Root backend",         paths: ["logs/pulsar.log"] },
-  { key: "2", label: "server",  desc: "Server / framework",   paths: ["logs/pulsar.s.log"] },
-  { key: "3", label: "browser", desc: "Browser / CDP ops",    paths: ["logs/pulsar.bs.log"] },
-  { key: "4", label: "api",     desc: "Scrape API tasks",     paths: ["logs/pulsar.api.log"] },
-  { key: "5", label: "pages",   desc: "Page processing",      paths: ["logs/pulsar.pg.log"] },
-  { key: "6", label: "coworker","desc": "Coworker task runner",paths: ["__coworker__"] },
-  { key: "7", label: "build",   desc: "Spring Boot build",    paths: [".build/spring-boot.log"] },
-  { key: "8", label: "startup", desc: "Server startup log",   paths: ["__startup__"] },
-  { key: "9", label: "combined","desc": "pulsar + server + browser", paths: ["logs/pulsar.log", "logs/pulsar.s.log", "logs/pulsar.bs.log"] },
-  { key: "0", label: "git",     desc: "Git log",              paths: ["__git__"] },
-  { key: "r", label: "rws",     desc: "RWS test output",      paths: ["__rws__"] },
+  { key: "1", label: "pulsar",  desc: "Root backend",         paths: ["logs/pulsar.log"], group: "logs" },
+  { key: "2", label: "server",  desc: "Server / framework",   paths: ["logs/pulsar.s.log"], group: "logs" },
+  { key: "3", label: "browser", desc: "Browser / CDP ops",    paths: ["logs/pulsar.bs.log"], group: "logs" },
+  { key: "4", label: "api",     desc: "Scrape API tasks",     paths: ["logs/pulsar.api.log"], group: "logs" },
+  { key: "5", label: "pages",   desc: "Page processing",      paths: ["logs/pulsar.pg.log"], group: "logs" },
+  { key: "6", label: "coworker","desc": "Coworker task runner",paths: ["__coworker__"], group: "system" },
+  { key: "7", label: "build",   desc: "Spring Boot build",    paths: [".build/spring-boot.log"], group: "system" },
+  { key: "8", label: "startup", desc: "Server startup log",   paths: ["__startup__"], group: "system" },
+  { key: "9", label: "combined","desc": "pulsar + server + browser", paths: ["logs/pulsar.log", "logs/pulsar.s.log", "logs/pulsar.bs.log"], group: "logs" },
+  { key: "0", label: "git",     desc: "Git log",              paths: ["__git__"], group: "tools" },
+  { key: "r", label: "rws",     desc: "RWS test output",      paths: ["__rws__"], group: "tools" },
 ];
 
 // ── State ──────────────────────────────────────────────────────────────
@@ -475,11 +484,24 @@ async function init() {
 }
 
 // ── Tab Rendering ──────────────────────────────────────────────────────
+var SOURCE_GROUPS = [
+  { id: "logs",   label: "Logs" },
+  { id: "system", label: "System" },
+  { id: "tools",  label: "Tools" },
+];
+
 function renderTabs() {
   var container = document.getElementById('source-tabs');
   var html = '';
+  var lastGroup = '';
   for (var i = 0; i < LOG_SOURCES.length; i++) {
     var src = LOG_SOURCES[i];
+    // Emit group label when group changes
+    if (src.group !== lastGroup) {
+      var g = SOURCE_GROUPS.find(function(g) { return g.id === src.group; });
+      if (g) html += '<span class="source-group-label">' + escHtml(g.label) + '</span>';
+      lastGroup = src.group;
+    }
     html += '<div class="source-tab" data-source="' + src.label +
       '" onclick="selectSourceById(\'' + src.label + '\')" title="' +
       escHtml(src.desc) + ' (' + src.key + ')">' +

--- a/coworker/gui/server.js
+++ b/coworker/gui/server.js
@@ -1135,6 +1135,339 @@ app.get('/api/issue-review/feedback', (req, res) => {
   res.json(stats);
 });
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Log Dashboard API
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── Log source definitions ──────────────────────────────────────────────
+
+const LOG_SOURCES = [
+  { key: "1", label: "pulsar",  desc: "Root backend",         paths: ["logs/pulsar.log"] },
+  { key: "2", label: "server",  desc: "Server / framework",   paths: ["logs/pulsar.s.log"] },
+  { key: "3", label: "browser", desc: "Browser / CDP ops",    paths: ["logs/pulsar.bs.log"] },
+  { key: "4", label: "api",     desc: "Scrape API tasks",     paths: ["logs/pulsar.api.log"] },
+  { key: "5", label: "pages",   desc: "Page processing",      paths: ["logs/pulsar.pg.log"] },
+  { key: "6", label: "coworker","desc": "Coworker task runner",paths: ["__coworker__"] },
+  { key: "7", label: "build",   desc: "Spring Boot build",    paths: [".build/spring-boot.log"] },
+  { key: "8", label: "startup", desc: "Server startup log",   paths: ["__startup__"] },
+  { key: "9", label: "combined","desc": "pulsar + server + browser", paths: ["logs/pulsar.log", "logs/pulsar.s.log", "logs/pulsar.bs.log"] },
+  { key: "0", label: "git",     desc: "Git log",              paths: ["__git__"] },
+  { key: "r", label: "rws",     desc: "RWS test output",      paths: ["__rws__"] },
+];
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function resolveRepoRoot() {
+  let d = path.resolve(__dirname, '..', '..');
+  while (d !== path.dirname(d)) {
+    if (fs.existsSync(path.join(d, '.git'))) return d;
+    d = path.dirname(d);
+  }
+  return path.resolve(__dirname, '..', '..');
+}
+
+const REPO_ROOT = resolveRepoRoot();
+
+function findLatestLogFile(dir, globPattern, excludePattern) {
+  if (!fs.existsSync(dir)) return null;
+  const results = [];
+  function walk(d) {
+    if (!fs.existsSync(d)) return;
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      if (entry.name.startsWith('.')) continue;
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) { walk(full); }
+      else {
+        // Simple glob: * matches any sequence
+        const regex = new RegExp('^' + globPattern.replace(/\*/g, '.*').replace(/\?/g, '.') + '$', 'i');
+        if (regex.test(entry.name)) {
+          if (excludePattern && new RegExp(excludePattern).test(entry.name)) continue;
+          try { results.push({ path: full, mtime: fs.statSync(full).mtimeMs }); }
+          catch(e) {}
+        }
+      }
+    }
+  }
+  walk(dir);
+  results.sort((a, b) => b.mtime - a.mtime);
+  return results.length > 0 ? results[0].path : null;
+}
+
+function resolveSourcePaths(source) {
+  const resolved = [];
+  const sentinel = source.paths[0] || '';
+
+  for (const p of source.paths) {
+    if (p === '__coworker__') {
+      const home = process.env.HOME || process.env.USERPROFILE || '.';
+      const cowDir = path.join(home, '.browser4-coworker', 'tasks', '300logs');
+      const latest = findLatestLogFile(cowDir, '*.log', '\\.std(out|err)$');
+      if (latest) resolved.push(latest);
+    } else if (p === '__startup__') {
+      const tempDir = process.env.BROWSER4_SERVER_LOG_DIR ||
+        path.join(process.env.HOME || process.env.USERPROFILE || '.', '.browser4', 'logs');
+      const latest = findLatestLogFile(tempDir, 'browser4-server-*.log', null);
+      if (latest) resolved.push(latest);
+    } else if (p === '__git__' || p === '__rws__') {
+      // Handled separately
+      resolved.push(p);
+    } else {
+      resolved.push(path.join(REPO_ROOT, p));
+    }
+  }
+  return resolved;
+}
+
+function labelFor(fp, source) {
+  if (source.paths.length <= 1) return '';
+  const name = path.basename(fp);
+  if (name.includes('pulsar.bs')) return 'browser';
+  if (name.includes('pulsar.s')) return 'server';
+  if (name.includes('pulsar')) return 'pulsar';
+  if (name.endsWith('.raw.md')) {
+    const stem = name.replace('.raw.md', '');
+    const parts = stem.split('-');
+    return parts.length > 1 ? parts.slice(1).join('-') : stem;
+  }
+  if (name.endsWith('-progress.json')) return name.replace('-progress.json', '');
+  if (name === 'test-session.json') return 'session';
+  return '';
+}
+
+function readTailLines(filePath, numLines) {
+  if (!fs.existsSync(filePath)) return { lines: [], size: 0 };
+  try {
+    const fd = fs.openSync(filePath, 'r');
+    const stat = fs.statSync(filePath);
+    const size = stat.size;
+    if (size === 0) { fs.closeSync(fd); return { lines: [], size: 0 }; }
+
+    // Estimate: average line ~200 bytes, read last numLines*200 bytes
+    const estBytes = numLines * 200;
+    const start = Math.max(0, size - estBytes);
+    const buf = Buffer.alloc(size - start);
+    fs.readSync(fd, buf, 0, buf.length, start);
+    fs.closeSync(fd);
+
+    let text = buf.toString('utf-8');
+    // If we started mid-line, drop the partial first line
+    if (start > 0) {
+      const nlIdx = text.indexOf('\n');
+      if (nlIdx >= 0) text = text.substring(nlIdx + 1);
+    }
+    const allLines = text.split(/\r?\n/);
+    // Take last numLines
+    const lines = allLines.slice(-numLines);
+    return { lines, size };
+  } catch(e) {
+    return { lines: [], size: 0 };
+  }
+}
+
+function readNewLines(filePath, lastPos) {
+  if (!fs.existsSync(filePath)) return { lines: [], size: lastPos };
+  try {
+    const stat = fs.statSync(filePath);
+    const currentSize = stat.size;
+    if (currentSize <= lastPos) return { lines: [], size: lastPos };
+
+    const fd = fs.openSync(filePath, 'r');
+    const buf = Buffer.alloc(currentSize - lastPos);
+    fs.readSync(fd, buf, 0, buf.length, lastPos);
+    fs.closeSync(fd);
+
+    const text = buf.toString('utf-8');
+    const lines = text.split(/\r?\n/);
+    // Remove trailing empty line from split
+    if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+    return { lines, size: currentSize };
+  } catch(e) {
+    return { lines: [], size: lastPos };
+  }
+}
+
+// ── RWS helpers ─────────────────────────────────────────────────────────
+
+function resolveRwsPaths() {
+  const resolved = [];
+  const targetDir = path.join(REPO_ROOT, 'target');
+  if (fs.existsSync(targetDir)) {
+    const rawFiles = [];
+    for (const entry of fs.readdirSync(targetDir, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith('.raw.md')) {
+        try {
+          rawFiles.push({ path: path.join(targetDir, entry.name), mtime: fs.statSync(path.join(targetDir, entry.name)).mtimeMs });
+        } catch(e) {}
+      }
+    }
+    rawFiles.sort((a, b) => b.mtime - a.mtime);
+    for (const rf of rawFiles.slice(0, 5)) resolved.push(rf.path);
+  }
+
+  const tsDir = path.join(REPO_ROOT, '.test-sessions');
+  if (fs.existsSync(tsDir)) {
+    // Progress files
+    const progFiles = [];
+    for (const entry of fs.readdirSync(tsDir, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith('-progress.json')) {
+        try {
+          progFiles.push({ path: path.join(tsDir, entry.name), mtime: fs.statSync(path.join(tsDir, entry.name)).mtimeMs });
+        } catch(e) {}
+      }
+    }
+    progFiles.sort((a, b) => b.mtime - a.mtime);
+    for (const pf of progFiles.slice(0, 5)) resolved.push(pf.path);
+
+    // Most recent test-session.json
+    const sessionFiles = [];
+    function findSessionFiles(d) {
+      if (!fs.existsSync(d)) return;
+      for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+        if (entry.name.startsWith('.')) continue;
+        const full = path.join(d, entry.name);
+        if (entry.isDirectory()) { findSessionFiles(full); }
+        else if (entry.name === 'test-session.json') {
+          try { sessionFiles.push({ path: full, mtime: fs.statSync(full).mtimeMs }); } catch(e) {}
+        }
+      }
+    }
+    findSessionFiles(tsDir);
+    sessionFiles.sort((a, b) => b.mtime - a.mtime);
+    if (sessionFiles.length > 0) resolved.push(sessionFiles[0].path);
+  }
+
+  return resolved;
+}
+
+// ── Routes ──────────────────────────────────────────────────────────────
+
+// GET /logs — serve the log dashboard SPA
+app.get('/logs', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'frontend', 'watch-logs.html'));
+});
+
+// POST /api/logs/tail — read tail of log files for a source
+app.post('/api/logs/tail', (req, res) => {
+  const { source: sourceKey, lines } = req.body;
+  const numLines = parseInt(lines) || 200;
+
+  const source = LOG_SOURCES.find(s => s.label === sourceKey || s.key === sourceKey);
+  if (!source) return res.status(400).json({ error: `Unknown source: ${sourceKey}` });
+
+  const sentinel = source.paths[0] || '';
+
+  if (sentinel === '__rws__') {
+    const rwsPaths = resolveRwsPaths();
+    const allLines = [];
+    const positions = {};
+    for (const fp of rwsPaths) {
+      const label = labelFor(fp, source);
+      const result = readTailLines(fp, Math.floor(numLines / Math.max(1, rwsPaths.length)));
+      for (const line of result.lines) {
+        allLines.push(label ? `[${label}] ${line}` : line);
+      }
+      positions[fp] = result.size;
+    }
+    return res.json({ lines: allLines, positions, message: rwsPaths.length === 0 ? 'No RWS files found' : null });
+  }
+
+  const resolved = resolveSourcePaths(source);
+  const allLines = [];
+  const positions = {};
+
+  for (const fp of resolved) {
+    const label = labelFor(fp, source);
+    const result = readTailLines(fp, Math.floor(numLines / Math.max(1, resolved.length)));
+    for (const line of result.lines) {
+      allLines.push(label ? `[${label}] ${line}` : line);
+    }
+    positions[fp] = result.size;
+  }
+
+  if (allLines.length === 0 && resolved.length === 0) {
+    allLines.push('(no log files found)');
+  }
+
+  res.json({ lines: allLines, positions });
+});
+
+// POST /api/logs/poll — poll for new content since given positions
+app.post('/api/logs/poll', (req, res) => {
+  const { source: sourceKey, positions } = req.body;
+  const pos = positions || {};
+
+  const source = LOG_SOURCES.find(s => s.label === sourceKey || s.key === sourceKey);
+  if (!source) return res.status(400).json({ error: `Unknown source: ${sourceKey}` });
+
+  const sentinel = source.paths[0] || '';
+
+  if (sentinel === '__rws__') {
+    const rwsPaths = resolveRwsPaths();
+    const allLines = [];
+    const newPositions = {};
+    // Add newly discovered files
+    for (const fp of rwsPaths) {
+      const lastPos = pos[fp] || 0;
+      const label = labelFor(fp, source);
+      const result = readNewLines(fp, lastPos);
+      for (const line of result.lines) {
+        allLines.push(label ? `[${label}] ${line}` : line);
+      }
+      newPositions[fp] = result.size;
+    }
+    // Keep positions for files that still exist
+    for (const fp of Object.keys(pos)) {
+      if (!(fp in newPositions)) newPositions[fp] = pos[fp];
+    }
+    return res.json({ lines: allLines, positions: newPositions });
+  }
+
+  const resolved = resolveSourcePaths(source);
+  const allLines = [];
+  const newPositions = {};
+
+  for (const fp of resolved) {
+    const lastPos = pos[fp] || 0;
+    const label = labelFor(fp, source);
+    const result = readNewLines(fp, lastPos);
+    for (const line of result.lines) {
+      allLines.push(label ? `[${label}] ${line}` : line);
+    }
+    newPositions[fp] = result.size;
+  }
+
+  res.json({ lines: allLines, positions: newPositions });
+});
+
+// GET /api/logs/git — fetch git log output
+app.get('/api/logs/git', (req, res) => {
+  const n = Math.min(parseInt(req.query.lines) || 50, 100);
+  const detail = req.query.detail === '1';
+  const now = new Date();
+  const timeStr = now.toTimeString().slice(0, 5);
+
+  let args;
+  let header;
+  if (detail) {
+    args = ['git', '-C', REPO_ROOT, 'log',
+      '--format=commit %H%d%nAuthor: %an <%ae>%nDate:   %ad%n%n    %B%n',
+      '--date=local', '--all', `--max-count=${n}`];
+    header = `──── git log detail (all branches, last ${n}) — ${timeStr} ────`;
+  } else {
+    args = ['git', '-C', REPO_ROOT, 'log',
+      '--oneline', '--graph', '--all', '--decorate', `-${n}`];
+    header = `──── git log (all branches, last ${n}) — ${timeStr} ────`;
+  }
+
+  execFile(args[0], args.slice(1), { timeout: 15000, maxBuffer: 1024 * 1024 }, (err, stdout) => {
+    if (err) {
+      return res.json({ lines: [`(git log error: ${err.message})`], header: '──── git log ────' });
+    }
+    const lines = (stdout || '').split(/\r?\n/);
+    res.json({ lines, header });
+  });
+});
+
 // ── Start server ────────────────────────────────────────────────────────
 
 app.listen(PORT, HOST, () => {


### PR DESCRIPTION
## Summary

Implements the functionality of `bin/tools/watch-logs.py` as a web-based log viewer in `coworker/gui`.

## What's included

### New page: `GET /logs`
A single-page log dashboard with all 11 log sources from the Python TUI:
- **pulsar** (1), **server** (2), **browser** (3), **api** (4), **pages** (5) — log file watchers
- **coworker** (6) — latest coworker task log auto-discovery
- **build** (7), **startup** (8) — build/startup log auto-discovery
- **combined** (9) — merged pulsar + server + browser
- **git** (0) — git log with compact/detail toggle
- **rws** (r) — RWS test output with STEP marker highlighting

### Features
- Severity-based colorization (FATAL/ERROR/SEVERE → red, WARN → yellow, etc.)
- Git log compact/detail toggle (press **g** on git tab)
- RWS test output with STEP start/pass/fail/abort colorization
- Live polling: 500ms (file sources), 2s (RWS), 10s (git)
- Regex search/filter with F3/Shift+F3 match navigation
- Pause/resume (space), clear (c), copy-to-clipboard (y)
- Auto-scroll with manual scroll detection
- Dark/light theme (defaults dark)
- Full keyboard shortcuts matching the Python TUI

### Server API
| Method | Path | Description |
|--------|------|-------------|
| GET | /logs | Serve the log dashboard SPA |
| POST | /api/logs/tail | Read tail of log files for a source |
| POST | /api/logs/poll | Poll for new content since given positions |
| GET | /api/logs/git | Fetch git log output |

### Files changed
- `coworker/gui/frontend/watch-logs.html` — new SPA (1082 lines)
- `coworker/gui/server.js` — added log API routes (+333 lines)
- `coworker/gui/frontend/index.html` — added /logs nav link (+1 line)
- `coworker/gui/README.md` — updated documentation

### How to test
```bash
cd coworker/gui
npm install
node server.js --open-browser
# Navigate to http://127.0.0.1:8090/logs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)