### PR TITLE
feat(bot-stealth): expand task to search + 5-service multi-check

### DIFF
--- a/browser4-tests/real-world-scenarios/tasks/real-world/generic/bot-stealth-check-md.md
+++ b/browser4-tests/real-world-scenarios/tasks/real-world/generic/bot-stealth-check-md.md
@@ -1,0 +1,36 @@
+# Bot stealth check
+
+## Phase 1 — Discover bot detection services
+
+1. Go to `https://www.google.com` and search for: `online bot detection test browser automation stealth check`.
+2. Read through the search results to identify at least 5 distinct online services that test whether a browser is a bot or automated.
+3. From the results, pick 5 reputable services. Good candidates include:
+   - `https://bot.sannysoft.com/`
+   - `https://browserscan.net/bot-detection`
+   - `https://bot.incolumitas.com/`
+   - `https://deviceandbrowserinfo.com/are_you_a_bot`
+   - `https://pixelscan.net/`
+   - `https://abrahamjuliot.github.io/creepjs/`
+   - `https://bot-detector.rebrowser.net/`
+
+   If any of these are unavailable, substitute others found in the search results.
+
+## Phase 2 — Run stealth checks on each service
+
+For each of the 5 selected services, do the following:
+
+4. **Navigate** to the service URL.
+5. **Wait** for the page to fully load and for any auto-detection to complete.
+6. **Take a full-page snapshot** to capture all visible results, scores, and pass/fail indicators.
+7. **Record the key findings:**
+   - Overall verdict (pass / fail / suspicious / score out of 100)
+   - Which specific checks passed or failed (e.g., WebDriver flag, headless detection, User-Agent consistency, canvas fingerprint, WebGL renderer, plugins check, `window.chrome` integrity)
+   - Any recommendations or explanations the service provides
+
+## Phase 3 — Report
+
+8. Compile the results from all 5 services into a markdown report saved to `./target/bot-stealth-report.md`.
+9. The report should include:
+   - A summary table listing each service, its URL, and the overall verdict/score
+   - Per-service details: which checks passed, which failed, and any notable warnings
+   - A conclusion: does Browser4 pass as a human browser, and if not, what specific signals gave it away


### PR DESCRIPTION
## What

Expands the bot-stealth-check task from a single-service stub into a comprehensive three-phase audit:

1. **Phase 1 — Discover**: Search Google for bot detection services, pick 5 from a curated list of 7 candidates
2. **Phase 2 — Run checks**: For each service, navigate, snapshot, and record verdicts + per-check pass/fail details
3. **Phase 3 — Report**: Compile a markdown report with a summary table, per-service details, and a conclusion about whether Browser4 passes as human

## Why

The original task only visited bot.sannysoft.com with generic instructions. The improved version tests Browser4's stealth against multiple independent detectors, which is the real goal — understanding which automation signals leak through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)