### PR TITLE
feat(test-production): add final upgrade step to ensure latest browser4-cli after tests

### DIFF
--- a/bin/test-production.ps1
+++ b/bin/test-production.ps1
@@ -1464,6 +1464,41 @@ if (-not $Stress) {
     }
 }
 
+# ═══════════════════════════════════════════════════════════════
+# FINAL STEP — Upgrade browser4-cli to latest version
+#
+# After all test cycles and stress tests have completed, perform a
+# final install/upgrade so the user is left with the latest version
+# of browser4-cli — regardless of what earlier steps may have
+# installed or uninstalled.
+# ═══════════════════════════════════════════════════════════════
+Write-StepHeader 'FINAL STEP — Upgrade browser4-cli to latest version'
+
+Write-Info 'Ensuring browser4-cli is at the latest version after all tests …'
+
+if ($Version) {
+    Write-Info "Installing specific version: $Version"
+}
+
+$finalUpgradeOk = Invoke-InstallFromRemoteScript
+if ($finalUpgradeOk) {
+    Update-SessionPath
+    $finalCliPath = Resolve-CliPath
+    if ($finalCliPath) {
+        $finalVersionResult = Invoke-CliCommand -Arguments @('--version')
+        $finalVersion = if ($finalVersionResult.ExitCode -eq 0) { $finalVersionResult.Output.Trim() } else { 'unknown' }
+        Write-Info "browser4-cli is now at: $finalVersion"
+        Write-StepResult -Step 'Final upgrade' -Passed $true `
+            -Detail "Installed: $finalVersion"
+    } else {
+        Write-StepResult -Step 'Final upgrade' -Passed $false `
+            -Detail 'Install script completed but browser4-cli not found on PATH'
+    }
+} else {
+    Write-StepResult -Step 'Final upgrade' -Passed $false `
+        -Detail 'Install script failed — browser4-cli may not be at latest version'
+}
+
 } finally {
     # ═══════════════════════════════════════════════════════════════
     # Cleanup (guaranteed to run even on error)
@@ -1552,6 +1587,7 @@ Write-Host "  Passed      : $PassedSteps" -ForegroundColor $(if ($PassedSteps -g
 Write-Host "  Failed      : $FailedSteps" -ForegroundColor $(if ($FailedSteps -eq 0) { 'Green' } else { 'Red' })
 Write-Host "  Cycle 1     : $(if ($cycle1Ok) { '✅ Clean-room install' } else { '❌ Clean-room install' })"
 Write-Host "  Cycle 2     : $(if ($cycle2Ok) { '✅ Re-install + timing' } else { '❌ Re-install + timing' })"
+Write-Host "  Final       : $(if ($finalUpgradeOk) { '✅ Upgrade to latest' } else { '❌ Upgrade to latest' })"
 
 if ($FailedSteps -gt 0) {
     Write-Host ''


### PR DESCRIPTION
## Summary

Adds a final upgrade step to `bin/test-production.ps1` that runs after all test cycles and stress tests complete.

## Problem

The script's existing flow (Cycle 1 → uninstall, Cycle 2 → uninstall, optional stress test) can leave the system without browser4-cli installed, or with an outdated version. A user running acceptance tests should end up with the latest version ready to use.

## Change

- New **FINAL STEP** section inserted after the stress test and before cleanup
- Calls `Invoke-InstallFromRemoteScript` to install/upgrade to the latest version
- Respects the `-Version` parameter when a specific version is being tested
- Verifies the CLI is on PATH and reports the installed version
- Updated the summary block to include the final upgrade status

## Flow after change

1. Pre-clean existing installation
2. Release status report
3. Cycle 1 — Clean-room install → test → uninstall
4. Cycle 2 — Re-install with config + timing → test → uninstall
5. Multi-scenarios stress test (opt-in)
6. **← NEW: Final upgrade to latest version**
7. Cleanup (kill servers, restore env vars)
8. Summary (now includes final upgrade status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)