### PR TITLE
fix(agentic): prevent trace filename collision when saves occur in same millisecond

### DIFF
--- a/browser4-agentic/src/main/kotlin/ai/platon/pulsar/agentic/tools/experience/KnowledgeStore.kt
+++ b/browser4-agentic/src/main/kotlin/ai/platon/pulsar/agentic/tools/experience/KnowledgeStore.kt
@@ -84,7 +84,11 @@ class KnowledgeStore(
         val timestamp = DateTimeFormatter.ofPattern("yyyy-MM-dd-HHmmss-SSS")
             .withZone(ZoneId.systemDefault()).format(trace.timestamp)
         val intentSlug = trace.intent.take(40).replace(Regex("[^a-zA-Z0-9_]"), "_")
-        val filename = "$timestamp-$intentSlug.yaml"
+
+        // Avoid filename collisions when multiple traces land in the same millisecond.
+        // Appends a short suffix from the traceId UUID which is always unique.
+        val shortId = trace.traceId.take(8)
+        val filename = "$timestamp-$intentSlug-$shortId.yaml"
         val file = domainDir.resolve(filename)
 
         writeAtomicYaml(file, mapFromTrace(trace))


### PR DESCRIPTION
## Problem

The v4.12.2 Maven Central release workflow [failed](https://github.com/platonai/Browser4/actions/runs/30517526842) because a test in `browser4-agentic` broke:

- **Test:** `KnowledgeStoreExtendedTest > Trace operations — edge cases > testListTracesPagination`
- **Error:** `expected: <1> but was: <0>` at line 393

## Root Cause

`saveTrace()` generates filenames using `yyyy-MM-dd-HHmmss-SSS` (millisecond precision). When 5 traces are saved in a tight loop, multiple traces can share the same millisecond timestamp + same intent → filename collision → overwrites. Only 4 unique files get created instead of 5, so page 3 returns 0 items instead of 1.

## Fix

Append the first 8 characters of `traceId` (a UUID) to the trace filename. This guarantees uniqueness regardless of timing, without changing the overall filename format.

## Verification

- `KnowledgeStoreExtendedTest$TraceEdgeCases` — all 4 tests pass (was 3/4)
- Full `browser4-agentic` test suite — 799 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)