### PR TITLE
feat(coworker): trigger full CI pipeline when >5 PRs merged since last CI

### DIFF
--- a/coworker/scripts/workers/merge-prs.ps1
+++ b/coworker/scripts/workers/merge-prs.ps1
@@ -3,7 +3,8 @@
 .SYNOPSIS
     Merge open PRs targeting the current branch created by the current user,
     resolve conflicts via agent, run minimal tests, and queue a coworker task
-    on failure.
+    on failure. When more than -CiThreshold PRs have accumulated since the
+    last CI run, triggers a full CI pipeline via monitor-ci.ps1 instead.
 
 .DESCRIPTION
     1. Lists open PRs targeting the current branch via gh CLI.
@@ -12,9 +13,13 @@
     3. For each PR: attempts direct merge; on conflict, checks out the PR
        branch, merges base, invokes the agent to resolve conflicts, pushes,
        then merges.
-    4. Runs minimal tests (./bin/test.ps1 fast).
-    5. If tests fail, writes a coworker task file into 1ready and triggers
-       process-coworker-queue.
+    4. Updates a persistent merge counter (tracked across runs).
+    5. If the counter exceeds -CiThreshold (default 5), invokes
+       monitor-ci.ps1 to trigger and monitor the full CI pipeline. The
+       counter resets when CI is triggered.
+    6. Otherwise, runs local tests (./bin/test.ps1 fast).
+    7. If tests or CI fail, writes a coworker task file into 1ready and
+       triggers process-coworker-queue.
 
 .PARAMETER TestType
     Test types to run after merges (default: "fast"). Passed to ./bin/test.ps1.
@@ -32,6 +37,12 @@
 .PARAMETER AllAuthors
     Merge all open PRs regardless of author. Default: only merge PRs created
     by the currently authenticated GitHub user.
+
+.PARAMETER CiThreshold
+    Number of PRs merged since last CI run that triggers a full CI pipeline
+    via monitor-ci.ps1 instead of local tests. Default: 5.
+    The counter is persistent across merge-prs.ps1 runs and resets when CI
+    is triggered.
 #>
 
 param(
@@ -40,7 +51,8 @@ param(
     [ValidateSet('--merge', '--squash', '--rebase')]
     [string]$MergeMethod = '--merge',
     [switch]$SkipTests,
-    [switch]$AllAuthors
+    [switch]$AllAuthors,
+    [int]$CiThreshold = 5
 )
 
 Set-StrictMode -Version Latest
@@ -74,6 +86,45 @@ if (-not (Test-Path $repoRoot)) {
     Write-Host "ERROR: Repository root not found."
     Remove-CoworkerScriptLock -Lock $script:__CoworkerLock
     exit 1
+}
+
+# ── CI merge-counter state (tracks PRs merged since last CI run) ──────────
+$ciStateDir = Join-Path $repoRoot '.coworker\state'
+$ciStateFile = Join-Path $ciStateDir 'ci-merge-counter.json'
+
+function Get-CiMergeState {
+    if (-not (Test-Path $ciStateFile)) {
+        return @{ mergedSinceLastCi = 0; lastCiTriggered = $null }
+    }
+    try {
+        $state = Get-Content -Path $ciStateFile -Raw -Encoding UTF8 | ConvertFrom-Json
+        return @{
+            mergedSinceLastCi = [int]$state.mergedSinceLastCi
+            lastCiTriggered   = $state.lastCiTriggered
+        }
+    }
+    catch {
+        Write-Host "WARN: Could not read CI merge state, resetting to 0." -ForegroundColor DarkGray
+        return @{ mergedSinceLastCi = 0; lastCiTriggered = $null }
+    }
+}
+
+function Set-CiMergeState {
+    param([int]$Count, [string]$LastTriggered)
+    if (-not (Test-Path $ciStateDir)) {
+        New-Item -ItemType Directory -Path $ciStateDir -Force | Out-Null
+    }
+    $state = @{
+        mergedSinceLastCi = $Count
+        lastCiTriggered   = $LastTriggered
+    }
+    $state | ConvertTo-Json -Compress | Set-Content -Path $ciStateFile -Encoding UTF8
+}
+
+function Reset-CiMergeCounter {
+    $now = Get-CoworkerTimestamp
+    Set-CiMergeState -Count 0 -LastTriggered $now
+    Write-Host "CI merge counter reset. Last CI triggered: $now" -ForegroundColor DarkGray
 }
 
 Push-Location $repoRoot
@@ -171,7 +222,7 @@ try {
         $prTitle = $pr.title
         $prBranch = $pr.headRefName
 
-        Write-Host "`n── PR #$prNum: $prTitle ──" -ForegroundColor Yellow
+        Write-Host "`n── PR #${prNum}: $prTitle ──" -ForegroundColor Yellow
 
         # Try direct merge first
         $mergeOutput = & gh pr merge $prNum $MergeMethod --delete-branch 2>&1
@@ -285,7 +336,15 @@ After resolving all conflicts, commit the merge. Do NOT push — the script hand
     Write-Host "  Merged after resolve: $($conflictResolved.Count) $($conflictResolved -join ', ')" -ForegroundColor Green
     Write-Host "  Skipped:              $($skipped.Count) $($skipped -join ', ')" -ForegroundColor Yellow
 
-    # ── Run tests ──────────────────────────────────────────────────────────
+    # ── Update CI merge counter ────────────────────────────────────────────
+    $totalMergedThisRun = $merged.Count + $conflictResolved.Count
+    $ciState = Get-CiMergeState
+    $mergedSinceLastCi = $ciState.mergedSinceLastCi + $totalMergedThisRun
+    Set-CiMergeState -Count $mergedSinceLastCi -LastTriggered $ciState.lastCiTriggered
+
+    Write-Host "PRs merged since last CI: $mergedSinceLastCi (threshold: $CiThreshold)" -ForegroundColor DarkGray
+
+    # ── Skip all tests ─────────────────────────────────────────────────────
     if ($SkipTests) {
         Write-Host "`nTests skipped (-SkipTests)." -ForegroundColor DarkGray
         Remove-CoworkerScriptLock -Lock $script:__CoworkerLock
@@ -293,7 +352,87 @@ After resolving all conflicts, commit the merge. Do NOT push — the script hand
         exit 0
     }
 
-    Write-Host "`n── Running minimal tests: ./bin/test.ps1 $TestType ──" -ForegroundColor Cyan
+    # ── Threshold exceeded: trigger full CI pipeline ───────────────────────
+    if ($mergedSinceLastCi -gt $CiThreshold) {
+        Write-Host "`n── $mergedSinceLastCi PRs merged since last CI (> $CiThreshold). Triggering CI pipeline... ──" -ForegroundColor Cyan
+
+        $monitorCiScript = Join-Path $PSScriptRoot 'monitor-ci.ps1'
+        if (-not (Test-Path $monitorCiScript)) {
+            Write-Host "WARN: monitor-ci.ps1 not found at $monitorCiScript. Falling back to local tests." -ForegroundColor Yellow
+            # Fall through to local tests below (counter is NOT reset)
+        }
+        else {
+            # Reset counter before invoking CI so we don't re-trigger on failure
+            Reset-CiMergeCounter
+
+            $ciArgs = @('-Ref', $BaseBranch)
+            $ciOutput = & pwsh -NoProfile -ExecutionPolicy Bypass -File $monitorCiScript @ciArgs 2>&1
+            $ciExitCode = $LASTEXITCODE
+
+            # Always show CI output
+            Write-Host ($ciOutput -join "`n")
+
+            if ($ciExitCode -eq 0) {
+                Write-Host "`nCI pipeline passed." -ForegroundColor Green
+                Remove-CoworkerScriptLock -Lock $script:__CoworkerLock
+                Pop-Location
+                exit 0
+            }
+
+            # CI failed — create coworker task
+            Write-Host "`nCI pipeline FAILED (exit $ciExitCode). Creating coworker task..." -ForegroundColor Red
+
+            $tasksRoot = Join-Path $repoRoot 'coworker\tasks\main'
+            $readyDir = Join-Path $tasksRoot '1ready'
+            if (-not (Test-Path $readyDir)) {
+                New-Item -ItemType Directory -Path $readyDir -Force | Out-Null
+            }
+
+            $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+            $taskFileName = "fix-ci-after-pr-merge-$timestamp.md"
+            $taskFilePath = Join-Path $readyDir $taskFileName
+
+            $mergedSummary = if ($merged.Count -gt 0) { "Merged: #$($merged -join ', #')" } else { "No direct merges" }
+            $resolvedSummary = if ($conflictResolved.Count -gt 0) { "Resolved: #$($conflictResolved -join ', #')" } else { "No conflict resolutions" }
+
+            $taskContent = @"
+Title: Fix CI failures after PR merge into $BaseBranch
+Description: CI pipeline failed after merging $totalMergedThisRun PR(s) into $BaseBranch. $mergedSummary. $resolvedSummary.
+Prompt: |
+  The following PRs were just merged into `$BaseBranch`:
+  - Direct merges: $($merged -join ', ' -replace '^$','none')
+  - Conflict-resolved merges: $($conflictResolved -join ', ' -replace '^$','none')
+
+  CI pipeline failed with exit code $ciExitCode. Investigate the CI failures
+  and fix them. Read the CI output above, identify the root cause(s), and
+  apply fixes.
+
+  CI workflow: ci.yml (ref: $BaseBranch)
+
+  #auto-approve
+"@
+
+            Set-Content -Path $taskFilePath -Value $taskContent -Encoding UTF8
+            Write-Host "  Task written: $taskFilePath" -ForegroundColor Cyan
+
+            # Trigger coworker to process the task
+            $queueScript = Join-Path $scriptsRoot 'process-coworker-queue.ps1'
+            if (Test-Path $queueScript) {
+                Write-Host "  Triggering coworker queue processor..." -ForegroundColor Cyan
+                & pwsh -NoProfile -ExecutionPolicy Bypass -File $queueScript -Once 2>&1 | Out-Null
+            }
+            else {
+                Write-Host "  WARN: process-coworker-queue.ps1 not found. Task awaits scheduler." -ForegroundColor Yellow
+            }
+
+            Remove-CoworkerScriptLock -Lock $script:__CoworkerLock
+            Pop-Location
+            exit 1
+        }
+    }
+
+    # ── Within threshold: run local tests ──────────────────────────────────
+    Write-Host "`n── Running local tests: ./bin/test.ps1 $TestType ──" -ForegroundColor Cyan
     $testScript = Join-Path $repoRoot 'bin\test.ps1'
     if (-not (Test-Path $testScript)) {
         Write-Host "WARN: test.ps1 not found at $testScript. Skipping tests." -ForegroundColor Yellow

--- a/coworker/scripts/workers/monitor-ci.ps1
+++ b/coworker/scripts/workers/monitor-ci.ps1
@@ -1,0 +1,189 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Trigger and monitor a GitHub Actions CI workflow run.
+
+.DESCRIPTION
+    1. Triggers the specified workflow via gh workflow run.
+    2. Polls for the newly created workflow run ID.
+    3. Streams run progress with gh run watch.
+    4. Reports the final conclusion and exits with the appropriate code.
+    5. On success, resets the CI merge counter so merge-prs.ps1 starts a
+       fresh accumulation window.
+
+.PARAMETER Workflow
+    Workflow file name or ID to trigger. Default: ci.yml.
+
+.PARAMETER Ref
+    Branch or tag to run the workflow against. Default: current branch.
+
+.PARAMETER TimeoutMinutes
+    Maximum time to wait for the workflow to complete. Default: 60.
+
+.PARAMETER PollIntervalSeconds
+    How often to poll for the run ID after triggering. Default: 5.
+#>
+
+param(
+    [string]$Workflow = 'ci.yml',
+    [string]$Ref = '',
+    [int]$TimeoutMinutes = 60,
+    [int]$PollIntervalSeconds = 5
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ── Load shared utilities ──────────────────────────────────────────────────
+$scriptsRoot = Split-Path -Parent $PSScriptRoot
+$configPath = Join-Path $scriptsRoot 'config.ps1'
+if (Test-Path $configPath) { . $configPath }
+
+# ── Resolve repository root ────────────────────────────────────────────────
+$repoRoot = Get-TargetRepositoryRoot
+if (-not $repoRoot) { $repoRoot = Get-WorkspaceRoot }
+if (-not (Test-Path $repoRoot)) {
+    Write-Host "ERROR: Repository root not found."
+    exit 1
+}
+
+Push-Location $repoRoot
+try {
+    # ── Verify prerequisites ───────────────────────────────────────────────
+    $ghCmd = Get-Command gh -ErrorAction SilentlyContinue
+    if (-not $ghCmd) {
+        Write-Host "ERROR: gh CLI is not installed or not on PATH."
+        Pop-Location
+        exit 1
+    }
+
+    # ── Resolve ref ────────────────────────────────────────────────────────
+    if (-not $Ref) {
+        $Ref = & git rev-parse --abbrev-ref HEAD 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "ERROR: Could not determine current branch."
+            Pop-Location
+            exit 1
+        }
+    }
+    Write-Host "CI Workflow: $Workflow" -ForegroundColor Cyan
+    Write-Host "Ref:         $Ref" -ForegroundColor Cyan
+
+    # Ensure the ref exists on the remote
+    & git fetch origin $Ref 2>&1 | Out-Null
+
+    # ── Trigger the workflow ───────────────────────────────────────────────
+    Write-Host "`n── Triggering workflow: gh workflow run $Workflow --ref $Ref ──" -ForegroundColor Yellow
+    $triggerOutput = & gh workflow run $Workflow --ref $Ref 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: Failed to trigger workflow: $triggerOutput" -ForegroundColor Red
+        Pop-Location
+        exit 1
+    }
+    Write-Host "Workflow triggered successfully." -ForegroundColor Green
+
+    # ── Find the new run ───────────────────────────────────────────────────
+    # The triggered run may take a moment to appear. Poll until we find it.
+    Write-Host "`n── Waiting for workflow run to appear... ──" -ForegroundColor Yellow
+    $runId = $null
+    $pollDeadline = (Get-Date).AddMinutes(2)
+    $knownRunIds = @{}
+
+    # Seed: capture existing runs so we can detect the new one
+    $existingRuns = & gh run list --workflow=$Workflow --limit=10 --json databaseId 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $existing = @($existingRuns | ConvertFrom-Json)
+        foreach ($r in $existing) { $knownRunIds[$r.databaseId] = $true }
+    }
+
+    while (-not $runId -and (Get-Date) -lt $pollDeadline) {
+        Start-Sleep -Seconds $PollIntervalSeconds
+        $runsJson = & gh run list --workflow=$Workflow --limit=10 --json databaseId,status,createdAt 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  Waiting for run list..." -ForegroundColor DarkGray
+            continue
+        }
+        $runs = @($runsJson | ConvertFrom-Json)
+        foreach ($r in $runs) {
+            if (-not $knownRunIds.ContainsKey($r.databaseId)) {
+                $runId = $r.databaseId
+                Write-Host "Found new run: $runId (status: $($r.status))" -ForegroundColor Green
+                break
+            }
+        }
+    }
+
+    if (-not $runId) {
+        Write-Host "ERROR: Could not find the triggered workflow run within 2 minutes." -ForegroundColor Red
+        Pop-Location
+        exit 1
+    }
+
+    # ── Monitor the run ────────────────────────────────────────────────────
+    Write-Host "`n── Monitoring run $runId (timeout: ${TimeoutMinutes}m)... ──" -ForegroundColor Cyan
+    Write-Host "  URL: $(& gh run view $runId --json url --jq '.url' 2>&1)" -ForegroundColor DarkGray
+
+    # gh run watch blocks until the run completes, showing live progress.
+    # We don't rely on its exit code — the conclusion check below is authoritative.
+    $watchOutput = & gh run watch $runId 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "WARN: gh run watch exited with code $LASTEXITCODE. Checking conclusion..." -ForegroundColor Yellow
+    }
+
+    # ── Get the final conclusion ───────────────────────────────────────────
+    $conclusion = ''
+    $runView = & gh run view $runId --json conclusion,status,displayTitle,headBranch 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $runInfo = $runView | ConvertFrom-Json
+        $conclusion = $runInfo.conclusion
+        Write-Host "`n========== CI Run Summary ==========" -ForegroundColor Cyan
+        Write-Host "  Workflow:   $($runInfo.displayTitle)" -ForegroundColor White
+        Write-Host "  Branch:     $($runInfo.headBranch)" -ForegroundColor White
+        Write-Host "  Status:     $($runInfo.status)" -ForegroundColor White
+        Write-Host "  Conclusion: $conclusion" -ForegroundColor ($conclusion -eq 'success' ? 'Green' : 'Red')
+    }
+    else {
+        Write-Host "WARN: Could not retrieve run conclusion." -ForegroundColor Yellow
+    }
+
+    # ── Reset CI merge counter on success ──────────────────────────────────
+    if ($conclusion -eq 'success') {
+        $ciStateDir = Join-Path $repoRoot '.coworker\state'
+        $ciStateFile = Join-Path $ciStateDir 'ci-merge-counter.json'
+        if (-not (Test-Path $ciStateDir)) {
+            New-Item -ItemType Directory -Path $ciStateDir -Force | Out-Null
+        }
+        $state = @{
+            mergedSinceLastCi = 0
+            lastCiTriggered   = Get-CoworkerTimestamp
+        }
+        $state | ConvertTo-Json -Compress | Set-Content -Path $ciStateFile -Encoding UTF8
+        Write-Host "CI merge counter reset." -ForegroundColor DarkGray
+    }
+
+    # ── Exit with the appropriate code ─────────────────────────────────────
+    if ($conclusion -eq 'success') {
+        Write-Host "`nCI pipeline SUCCEEDED." -ForegroundColor Green
+        Pop-Location
+        exit 0
+    }
+    elseif ($conclusion -eq 'cancelled') {
+        Write-Host "`nCI pipeline was CANCELLED." -ForegroundColor Yellow
+        Pop-Location
+        exit 2
+    }
+    else {
+        Write-Host "`nCI pipeline FAILED (conclusion: $conclusion)." -ForegroundColor Red
+        # Show failed jobs if available
+        $failedJobs = & gh run view $runId --json jobs --jq '.jobs[] | select(.conclusion == "failure") | "  \(.name)"' 2>&1
+        if ($LASTEXITCODE -eq 0 -and $failedJobs) {
+            Write-Host "Failed jobs:" -ForegroundColor Red
+            Write-Host $failedJobs
+        }
+        Pop-Location
+        exit 1
+    }
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary

Improves `merge-prs.ps1` to track PRs merged since the last CI run and automatically trigger a full CI pipeline when the count exceeds a configurable threshold (default: 5).

## Changes

### `merge-prs.ps1`
- **New `-CiThreshold` parameter** (default: 5) — controls how many PRs can accumulate before triggering full CI
- **Persistent merge counter** stored in `.coworker/state/ci-merge-counter.json` — survives across script runs
- **Threshold-aware routing:**
  - When cumulative merged PRs ≤ threshold → runs local tests (`./bin/test.ps1`) as before
  - When cumulative merged PRs > threshold → invokes `monitor-ci.ps1` to trigger and monitor the full CI pipeline, then resets the counter
  - Falls back to local tests if `monitor-ci.ps1` is not found

### `monitor-ci.ps1` (new)
- Triggers the `ci.yml` GitHub Actions workflow via `gh workflow run`
- Polls for the new run ID, then streams live progress with `gh run watch`
- Reports final conclusion (success/failure/cancelled) with failed job names
- Resets the CI merge counter on success
- Supports `-Workflow`, `-Ref`, `-TimeoutMinutes`, and `-PollIntervalSeconds` parameters

## Flow



🤖 Generated with [Claude Code](https://claude.com/claude-code)