### PR TITLE
fix(coworker): correct TargetRepositoryRoot config from '../' to '../..'

### DIFF
--- a/coworker/scripts/config.psd1
+++ b/coworker/scripts/config.psd1
@@ -3,7 +3,7 @@
         WorkspaceRoot        = '../..'
         CoworkerRoot         = '..'
         TasksRoot            = '../tasks'
-        TargetRepositoryRoot = '../'
+        TargetRepositoryRoot = '../..'
         LogDirectory         = '~/.browser4-coworker/tasks/300logs'
     }
 


### PR DESCRIPTION
## Problem

`TargetRepositoryRoot` in `coworker/scripts/config.psd1` was set to `'../'`, which resolves to the `coworker/` directory instead of the actual repository root.

This caused `merge-prs.ps1` to look for `bin/test.ps1` at `coworker/bin/test.ps1` (which doesn't exist) instead of `bin/test.ps1` at the repo root.

## Fix

Changed `TargetRepositoryRoot` from `'../'` to `'../..'`, matching the `WorkspaceRoot` value. Now it correctly resolves to the repository root where `.git` and `bin/test.ps1` live.

## Affected consumers

All of these expect the actual git repository root for running tests, git operations, and agent working directories:

- `merge-prs.ps1` — runs `bin/test.ps1`
- `git-commit.ps1` — git commits in target repo
- `engineer.ps1` — agent working directory
- `coworker.ps1` — Invoke-Commit / Invoke-Push

🤖 Generated with [Claude Code](https://claude.com/claude-code)