### PR TITLE
fix(b4w): coworker review command truncated to first character

### DIFF
--- a/b4w.ps1
+++ b/b4w.ps1
@@ -131,7 +131,7 @@ if ($RemainingArgs -and ($RemainingArgs[0] -eq '--' -or $RemainingArgs[0] -eq '-
 # Delegates to coworker/coworker.ps1, forwarding all remaining arguments.
 if ($CliArgs -and $CliArgs[0] -eq 'coworker') {
     $CoworkerScript = Join-Path $ScriptDir 'coworker\coworker.ps1'
-    $CoworkerArgs = if ($CliArgs.Count -gt 1) { $CliArgs[1..($CliArgs.Count - 1)] } else { @() }
+    $CoworkerArgs = if ($CliArgs.Count -gt 1) { @($CliArgs[1..($CliArgs.Count - 1)]) } else { @() }
     if ($CoworkerArgs) {
         $CoworkerCommand = $CoworkerArgs[0]
         $CoworkerRemaining = @()


### PR DESCRIPTION
## Problem

`b4w coworker review` fails with `Unknown command: r` instead of executing the review command.

## Root cause

In `b4w.ps1`, the array slice `$CliArgs[1..(N-1)]` uses PowerShell's range operator `..`. When there are exactly 2 CLI args (e.g., `coworker` + `review`), the range `1..1` evaluates to the **scalar** integer `1`, not an array. PowerShell's array indexing with a scalar index returns the element directly — so the slice returns a **scalar string** `'review'` rather than `@('review')`.

Then `$CoworkerArgs[0]` on a string indexes by character, returning `'r'` — the first letter of `'review'`.

## Fix

Wrap the slice in `@()` to force array output:

```diff
- $CoworkerArgs = if ($CliArgs.Count -gt 1) { $CliArgs[1..($CliArgs.Count - 1)] } else { @() }
+ $CoworkerArgs = if ($CliArgs.Count -gt 1) { @($CliArgs[1..($CliArgs.Count - 1)]) } else { @() }
```

The `test` and `build` subcommand handlers use the same pattern but are not affected because they use splatting (`@TestArgs`) which handles scalar strings correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)