### PR TITLE
feat(cli): add chat command for AI conversation

### DIFF
--- a/cli/browser4-cli/src/commands.rs
+++ b/cli/browser4-cli/src/commands.rs
@@ -2421,6 +2421,46 @@ pub fn all_commands() -> Vec<CommandDef> {
             },
         },
         CommandDef {
+            name: "chat",
+            description: "Chat with AI without any auto-appended context",
+            category: Category::Agent,
+            hidden: false,
+            batch_supported: false,
+            args: &[ArgDef { name: "prompt", description: "Message to send to the AI", optional: false }],
+            options: &[
+                OptionDef {
+                    name: "async",
+                    description: "Submit asynchronously and return a task ID for later polling",
+                    is_bool: true,
+                    short: None,
+                },
+            ],
+            e2e_coverage: E2eCoverage::Tested,
+            tool_name_fn: |_| String::new(),
+            tool_params_fn: |args| {
+                let mut p = json!({});
+                if let Some(prompt) = get_opt_str(args, "prompt") { p["prompt"] = json!(prompt); }
+                if let Some(true) = get_bool(args, "async") { p["async"] = json!(true); }
+                p
+            },
+        },
+        CommandDef {
+            name: "chat-result",
+            description: "Get the result of an async chat task",
+            category: Category::Agent,
+            hidden: false,
+            batch_supported: false,
+            args: &[ArgDef { name: "id", description: "Task ID returned by chat --async", optional: false }],
+            options: &[],
+            e2e_coverage: E2eCoverage::Tested,
+            tool_name_fn: |_| String::new(),
+            tool_params_fn: |args| {
+                let mut p = json!({});
+                if let Some(id) = get_opt_str(args, "id") { p["id"] = json!(id); }
+                p
+            },
+        },
+        CommandDef {
             name: "agent-run",
             description: "Run an autonomous agent task (async, returns task ID)",
             category: Category::Agent,
@@ -3451,6 +3491,8 @@ mod tests {
             "uninstall",
             "doctor",
             "batch",
+            "chat",
+            "chat-result",
             "loop",
             "goto",
             "click",

--- a/cli/browser4-cli/src/http.rs
+++ b/cli/browser4-cli/src/http.rs
@@ -455,6 +455,130 @@ pub async fn submit_plain_command(
     .await
 }
 
+/// Send a chat message to the AI via the conversations API.
+/// Returns the AI's text response.
+pub async fn chat_with_ai(
+    client: &Client,
+    base_url: &str,
+    prompt: &str,
+) -> Result<String, String> {
+    let url = build_endpoint_url(base_url, "/api/conversations");
+    let timeout = std::time::Duration::from_secs(timeout_secs_from_env(
+        "BROWSER4_CLI_CHAT_TIMEOUT_SECS",
+        120,
+    ));
+    let response = client
+        .post(&url)
+        .header("Content-Type", "text/plain")
+        .body(prompt.to_string())
+        .timeout(timeout)
+        .send()
+        .await
+        .map_err(|e| {
+            if e.is_timeout() {
+                format!(
+                    "Chat request timed out after {}s. Increase with BROWSER4_CLI_CHAT_TIMEOUT_SECS env var.",
+                    timeout.as_secs()
+                )
+            } else {
+                format!("Failed to call chat endpoint: {e}")
+            }
+        })?;
+
+    let status = response.status();
+    let response_text = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read chat response body: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format_http_error(status, &response_text));
+    }
+
+    Ok(response_text)
+}
+
+/// Submit a chat message asynchronously via the conversations API.
+/// Returns a task ID that can be polled via the /api/conversations/{id} endpoint.
+pub async fn chat_with_ai_async(
+    client: &Client,
+    base_url: &str,
+    prompt: &str,
+) -> Result<String, String> {
+    let url = build_endpoint_url(base_url, "/api/conversations/async");
+    let timeout = std::time::Duration::from_secs(timeout_secs_from_env(
+        "BROWSER4_CLI_CHAT_TIMEOUT_SECS",
+        30,
+    ));
+    let response = client
+        .post(&url)
+        .header("Content-Type", "text/plain")
+        .body(prompt.to_string())
+        .timeout(timeout)
+        .send()
+        .await
+        .map_err(|e| {
+            if e.is_timeout() {
+                format!(
+                    "Chat async submission timed out after {}s.",
+                    timeout.as_secs()
+                )
+            } else {
+                format!("Failed to call chat async endpoint: {e}")
+            }
+        })?;
+
+    let status = response.status();
+    let response_text = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read chat async response body: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format_http_error(status, &response_text));
+    }
+
+    // The async endpoint returns a task ID as plain text (possibly JSON-quoted)
+    Ok(response_text.trim().trim_matches('"').to_string())
+}
+
+/// Poll for the result of an async chat task.
+pub async fn get_chat_result(
+    client: &Client,
+    base_url: &str,
+    task_id: &str,
+) -> Result<String, String> {
+    let url = build_endpoint_url(base_url, &format!("/api/conversations/{}", task_id));
+    let timeout = std::time::Duration::from_secs(timeout_secs_from_env(
+        "BROWSER4_CLI_CHAT_TIMEOUT_SECS",
+        120,
+    ));
+    let response = client
+        .get(&url)
+        .timeout(timeout)
+        .send()
+        .await
+        .map_err(|e| {
+            if e.is_timeout() {
+                format!("Chat result request timed out after {}s.", timeout.as_secs())
+            } else {
+                format!("Failed to get chat result: {e}")
+            }
+        })?;
+
+    let status = response.status();
+    let response_text = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read chat result body: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format_http_error(status, &response_text));
+    }
+
+    Ok(response_text)
+}
+
 /// Submit a natural language description to the server, which translates it
 /// to a CLI command via LLM and executes it synchronously.
 /// Returns the command output on success.

--- a/cli/browser4-cli/src/main.rs
+++ b/cli/browser4-cli/src/main.rs
@@ -342,6 +342,8 @@ fn no_snapshot_commands() -> HashSet<&'static str> {
         "goto",
         "act",
         "batch",
+        "chat",
+        "chat-result",
         "close",
         "disconnect",
         "close-all",
@@ -8475,6 +8477,60 @@ async fn handle_agent_run(
     Ok(())
 }
 
+async fn handle_chat(
+    client: &Client,
+    base_url: &str,
+    tool_params: &Value,
+) -> Result<(), String> {
+    let prompt = tool_params
+        .get("prompt")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+
+    if prompt.is_empty() {
+        return Err("A prompt is required. Usage: browser4-cli chat \"<message>\"".to_string());
+    }
+
+    let is_async = tool_params
+        .get("async")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if is_async {
+        let task_id = http::chat_with_ai_async(client, base_url, prompt).await?;
+        cli_println!("Chat task submitted: {}", task_id);
+        cli_println!(
+            "Use 'browser4-cli chat-result {}' to get the response.",
+            task_id
+        );
+    } else {
+        let response = http::chat_with_ai(client, base_url, prompt).await?;
+        cli_println!("{}", response);
+    }
+
+    Ok(())
+}
+
+async fn handle_chat_result(
+    client: &Client,
+    base_url: &str,
+    tool_params: &Value,
+) -> Result<(), String> {
+    let task_id = tool_params
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+
+    if task_id.is_empty() {
+        return Err("A task ID is required. Usage: browser4-cli chat-result <id>".to_string());
+    }
+
+    let response = http::get_chat_result(client, base_url, task_id).await?;
+    cli_println!("{}", response);
+
+    Ok(())
+}
+
 async fn handle_act(
     client: &Client,
     base_url: &str,
@@ -16536,6 +16592,12 @@ async fn run(
             .await?;
         }
         // Agent commands
+        "chat" => {
+            handle_chat(&client, &base_url, &tool_params).await?;
+        }
+        "chat-result" => {
+            handle_chat_result(&client, &base_url, &tool_params).await?;
+        }
         "agent-run" => {
             handle_agent_run(
                 &client,

--- a/cli/browser4-cli/src/main.rs
+++ b/cli/browser4-cli/src/main.rs
@@ -8500,7 +8500,7 @@ async fn handle_chat(
         let task_id = http::chat_with_ai_async(client, base_url, prompt).await?;
         cli_println!("Chat task submitted: {}", task_id);
         cli_println!(
-            "Use 'browser4-cli chat-result {}' to get the response.",
+            "Use 'browser4-cli chat result {}' to get the response.",
             task_id
         );
     } else {
@@ -8522,7 +8522,7 @@ async fn handle_chat_result(
         .unwrap_or_default();
 
     if task_id.is_empty() {
-        return Err("A task ID is required. Usage: browser4-cli chat-result <id>".to_string());
+        return Err("A task ID is required. Usage: browser4-cli chat result <id>".to_string());
     }
 
     let response = http::get_chat_result(client, base_url, task_id).await?;
@@ -14564,6 +14564,17 @@ fn rewrite_prefixed_command(args: &[String]) -> Option<Vec<String>> {
             }
         }
     }
+    // "chat" works standalone (chat <prompt>) AND as a prefix (chat result).
+    // Only rewrite known chat subcommands so positional prompts pass through.
+    if prefix == "chat" {
+        let known_subs = ["result"];
+        if known_subs.contains(&sub.as_str()) {
+            let mut rewritten = vec![format!("chat-{}", sub)];
+            rewritten.extend(args[2..].iter().cloned());
+            return Some(rewritten);
+        }
+        return None;
+    }
     // "crawl" works standalone (crawl <url>) AND as a prefix (crawl list).
     // Only rewrite known crawl subcommands so positional URLs pass through.
     if prefix == "crawl" {
@@ -14652,6 +14663,7 @@ fn preferred_spaced_command_form(command: &str) -> Option<&'static str> {
         "swarm-result" => Some("swarm result"),
         "swarm-list" => Some("swarm list"),
         "swarm-close" => Some("swarm close"),
+        "chat-result" => Some("chat result"),
         "crawl-status" => Some("crawl status"),
         "crawl-result" => Some("crawl result"),
         "crawl-cancel" => Some("crawl cancel"),
@@ -20206,8 +20218,44 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Chat command rewriting tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rewrite_prefixed_command_supports_chat_result() {
+        let rewritten = rewrite_prefixed_command(&[
+            "chat".to_string(),
+            "result".to_string(),
+            "task-id-123".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(rewritten[0], "chat-result");
+        assert_eq!(rewritten[1], "task-id-123");
+    }
+
+    #[test]
+    fn rewrite_prefixed_command_chat_with_prompt_passes_through() {
+        // chat <prompt> should NOT be rewritten — it's a standalone chat command
+        let result = rewrite_prefixed_command(&[
+            "chat".to_string(),
+            "What is the capital of France?".to_string(),
+        ]);
+
+        assert!(result.is_none(), "chat <prompt> should not be rewritten");
+    }
+
+    // -----------------------------------------------------------------------
     // preferred_spaced_command_form tests
     // -----------------------------------------------------------------------
+
+    #[test]
+    fn preferred_spaced_command_form_includes_chat_result() {
+        assert_eq!(
+            preferred_spaced_command_form("chat-result"),
+            Some("chat result")
+        );
+    }
 
     #[test]
     fn preferred_spaced_command_form_includes_crawl_status() {


### PR DESCRIPTION
Adds chat and chat-result CLI commands. Uses existing /api/conversations backend endpoint. No backend changes.