### PR TITLE
test(e2e): add chat and chat-result to e2e command coverage

### DIFF
--- a/cli/browser4-cli/tests/e2e/mod.rs
+++ b/cli/browser4-cli/tests/e2e/mod.rs
@@ -629,6 +629,9 @@ struct MockBrowser4State {
     /// Custom browser_snapshot response. When set, overrides the default mock
     /// response for `browser_snapshot` tool calls (used by snapshot-grep, etc.).
     custom_browser_snapshot_response: Option<String>,
+    /// Track async chat submissions (prompt → task_id).
+    chat_async_submissions: Vec<(String, String)>,
+    next_chat_task_id: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1382,6 +1385,57 @@ fn serve_mock_browser4_request(mut stream: TcpStream, state: Arc<Mutex<MockBrows
             })
             .to_string();
             write_http_response(&mut stream, "200 OK", "application/json", &response);
+        }
+        // ---- chat REST endpoints ----
+        _ if method == "POST" && route == "/api/conversations" => {
+            let prompt = String::from_utf8_lossy(&body).trim().to_string();
+            state
+                .lock()
+                .expect("mock Browser4 state mutex poisoned")
+                .plain_commands
+                .push(prompt);
+            // Return a mock AI chat response
+            write_http_response(
+                &mut stream,
+                "200 OK",
+                "text/plain; charset=utf-8",
+                "Mock chat response for your prompt.",
+            );
+        }
+        _ if method == "POST" && route == "/api/conversations/async" => {
+            let prompt = String::from_utf8_lossy(&body).trim().to_string();
+            let task_id = {
+                let mut guard = state.lock().expect("mock Browser4 state mutex poisoned");
+                guard.next_chat_task_id += 1;
+                let task_id = format!("chat-task-{}", guard.next_chat_task_id);
+                guard
+                    .chat_async_submissions
+                    .push((prompt.clone(), task_id.clone()));
+                guard.plain_commands.push(prompt);
+                task_id
+            };
+            write_http_response(
+                &mut stream,
+                "200 OK",
+                "text/plain; charset=utf-8",
+                &format!("\"{}\"", task_id),
+            );
+        }
+        _ if method == "GET" && route.starts_with("/api/conversations/") => {
+            let task_id = route
+                .strip_prefix("/api/conversations/")
+                .unwrap_or_default();
+            state
+                .lock()
+                .expect("mock Browser4 state mutex poisoned")
+                .result_queries
+                .push(task_id.to_string());
+            write_http_response(
+                &mut stream,
+                "200 OK",
+                "text/plain; charset=utf-8",
+                &format!("Mock chat result for task {task_id}."),
+            );
         }
         _ => write_http_response(
             &mut stream,
@@ -4242,6 +4296,9 @@ fn tested_commands(include_batch_command: bool) -> HashSet<&'static str> {
         "agent-result",
         // test_agent_list_*, test_agent_full_lifecycle_with_mock
         "agent-list",
+        // test_chat_commands
+        "chat",
+        "chat-result",
         // test_swarm_submission_commands
         "swarm-create",
         "swarm-submit",

--- a/cli/browser4-cli/tests/e2e/scenarios/mock_server.rs
+++ b/cli/browser4-cli/tests/e2e/scenarios/mock_server.rs
@@ -5152,3 +5152,78 @@ pub(super) fn test_upload_error_backend_failure(ctx: &mut E2ECtx) {
 
     let _ = std::fs::remove_file(&tmp_path);
 }
+
+// ---------------------------------------------------------------------------
+// Chat commands — synchronous and async (chat / chat-result)
+// ---------------------------------------------------------------------------
+
+pub(super) fn test_chat_commands(ctx: &mut E2ECtx) {
+    reset_cli_artifacts(ctx);
+    let started_at = Instant::now();
+    let mock_server = MockBrowser4Server::start();
+    ctx.record_step("mock Browser4 server start", started_at.elapsed());
+    ctx.browser4_base_url = mock_server.base_url();
+
+    // ---- synchronous chat ----
+    let chat_result = run_command(ctx, &["chat", "Hello, how are you?"]);
+    assert!(
+        chat_result.stdout.contains("Mock chat response for your prompt."),
+        "Expected mock chat response in:\n{}",
+        chat_result.stdout
+    );
+
+    // ---- async chat ----
+    let async_result = run_command(ctx, &["chat", "--async", "Tell me a joke"]);
+    assert!(
+        async_result.stdout.contains("Chat task submitted:"),
+        "Expected async task submission output in:\n{}",
+        async_result.stdout
+    );
+    assert!(
+        async_result.stdout.contains("chat-task-"),
+        "Expected chat task ID in:\n{}",
+        async_result.stdout
+    );
+    assert!(
+        async_result.stdout.contains("chat result chat-task-"),
+        "Expected chat result hint in:\n{}",
+        async_result.stdout
+    );
+
+    // Extract task ID from output
+    let task_id: String = async_result
+        .stdout
+        .lines()
+        .find_map(|line| {
+            if line.contains("chat-task-") {
+                line.split("chat-task-")
+                    .nth(1)
+                    .map(|s| format!("chat-task-{}", s.trim().trim_matches(|c: char| !c.is_ascii_digit())))
+            } else {
+                None
+            }
+        })
+        .expect("Failed to extract chat task ID");
+
+    // ---- chat result ----
+    let result = run_command(ctx, &["chat", "result", &task_id]);
+    assert_eq!(
+        strip_snapshot_output(&result.stdout),
+        format!("Mock chat result for task {task_id}.")
+    );
+
+    // Verify mock server recorded the right calls
+    let snapshot = mock_server.snapshot();
+    assert_eq!(
+        snapshot.plain_commands,
+        vec![
+            "Hello, how are you?".to_string(),
+            "Tell me a joke".to_string(),
+        ]
+    );
+    assert!(
+        snapshot.result_queries.contains(&task_id),
+        "Expected chat-result to query task {task_id}, got {:?}",
+        snapshot.result_queries
+    );
+}

--- a/cli/browser4-cli/tests/e2e/scenarios/mod.rs
+++ b/cli/browser4-cli/tests/e2e/scenarios/mod.rs
@@ -1547,6 +1547,16 @@ pub(crate) const SCENARIOS: &[ScenarioDef] = &[
         level: ScenarioLevel::Basic,
     },
     ScenarioDef {
+        name: "test_e2e_chat_commands",
+        short_name: "test_chat_commands",
+        requires_browser4: false,
+        restart_browser4: false,
+        test_count: 1,
+        test_fn: mock_server::test_chat_commands,
+        group: Some("agent"),
+        level: ScenarioLevel::Basic,
+    },
+    ScenarioDef {
         name: "test_e2e_htmlsnapshot_error_propagation",
         short_name: "test_htmlsnapshot_error_propagation",
         requires_browser4: false,


### PR DESCRIPTION
## Summary

The chat and chat-result commands were marked E2eCoverage::Tested in commands.rs but were missing from tested_commands() and had no e2e test scenario. This caused test_e2e_command_coverage to panic.

## Changes

- Mock server: Added REST endpoint routes for POST /api/conversations (sync), POST /api/conversations/async (async submission), and GET /api/conversations/{id} (result polling)
- Test scenario: Added test_chat_commands — exercises synchronous chat, async chat --async, and chat result polling
- Scenario registry: Registered test_e2e_chat_commands under the agent group at Basic level
- Coverage: Added chat and chat-result to tested_commands()

🤖 Generated with [Claude Code](https://claude.com/claude-code)