### PR TITLE
fix(b4w): use comma operator for coworker args slice

### DIFF
--- a/b4w.ps1
+++ b/b4w.ps1
@@ -131,7 +131,7 @@ if ($RemainingArgs -and ($RemainingArgs[0] -eq '--' -or $RemainingArgs[0] -eq '-
 # Delegates to coworker/coworker.ps1, forwarding all remaining arguments.
 if ($CliArgs -and $CliArgs[0] -eq 'coworker') {
     $CoworkerScript = Join-Path $ScriptDir 'coworker\coworker.ps1'
-    $CoworkerArgs = if ($CliArgs.Count -gt 1) { @($CliArgs[1..($CliArgs.Count - 1)]) } else { @() }
+    $CoworkerArgs = if ($CliArgs.Count -gt 1) { ,$CliArgs[1..($CliArgs.Count - 1)] } else { @() }
     if ($CoworkerArgs) {
         $CoworkerCommand = $CoworkerArgs[0]
         $CoworkerRemaining = @()

--- a/coworker/scripts/review.ps1
+++ b/coworker/scripts/review.ps1
@@ -168,7 +168,7 @@ function Resolve-IssuesFile {
     }
 
     if ($Name) {
-        $allFiles = Find-IssuesFiles
+        $allFiles = @(Find-IssuesFiles)
         $searchLower = $Name.ToLowerInvariant()
         $matches = @($allFiles | Where-Object {
             (Split-Path -Leaf $_).ToLowerInvariant().Contains($searchLower)
@@ -1885,7 +1885,7 @@ function Invoke-Review {
         return
     }
 
-    $allFiles = Find-IssuesFiles -IncludeDone:$All
+    $allFiles = @(Find-IssuesFiles -IncludeDone:$All)
 
     # ── List mode ────────────────────────────────────────────────────────────
     if ($List) {
@@ -1957,7 +1957,7 @@ function Invoke-Review {
 
         # Done / discard / back-to-list — all return to the file picker
         if ($result -eq 'done' -or $result -eq 'discard' -or $result -eq 'back-to-list') {
-            $allFiles = Find-IssuesFiles -IncludeDone:$All
+            $allFiles = @(Find-IssuesFiles -IncludeDone:$All)
             $filePath = Show-FilePicker -Files $allFiles
             if (-not $filePath) { break }
             try {
@@ -1983,7 +1983,7 @@ function Invoke-Review {
         }
         if (-not $nextFilePath) {
             # Hit end of file list — go back to file picker
-            $allFiles = Find-IssuesFiles -IncludeDone:$All
+            $allFiles = @(Find-IssuesFiles -IncludeDone:$All)
             $filePath = Show-FilePicker -Files $allFiles
             if (-not $filePath) { break }
             try {


### PR DESCRIPTION
Fix: Use comma operator (,) instead of @() for array wrapping in if-expression. @() also unwinds to scalars in PowerShell if-as-expression. Co-Authored-By: Claude