### PR TITLE
fix(monitor): fix block numbering and undefined RunId in Extract-MinimalErrors

### DIFF
--- a/bin/ci/monitor-ci.ps1
+++ b/bin/ci/monitor-ci.ps1
@@ -59,7 +59,7 @@ $ErrorActionPreference = "Stop"
     near-duplicate blocks, and caps at a reasonable size.
 #>
 function Extract-MinimalErrors {
-    param([string[]]$LogLines)
+    param([string[]]$LogLines, [string]$RunId = '')
 
     $errorPatterns = @(
         'error:', 'Error:', 'ERROR:',
@@ -126,15 +126,20 @@ function Extract-MinimalErrors {
                 if (-not $prevWasSeparator -and $errors.Count -gt 0) {
                     $errors.Add("")
                 }
-                $errors.Add("══ block $($errors.Count / 2 + 1) ══")
+                $errors.Add("══ block $($seen.Count) ══")
                 $errors.Add($block)
                 $prevWasSeparator = $false
 
                 # Token safety: ~50 blocks max (≈200-300 lines)
                 if ($seen.Count -ge 50) {
                     $errors.Add("")
-                    $errors.Add("... (truncated at 50 blocks for token efficiency — run " +
-                                "`gh run view $RunId --log-failed` for full logs)")
+                    $truncationMsg = "... (truncated at 50 blocks for token efficiency"
+                    if ($RunId) {
+                        $truncationMsg += " — run `gh run view $RunId --log-failed` for full logs)"
+                    } else {
+                        $truncationMsg += " — use `gh run view --log-failed` for full logs)"
+                    }
+                    $errors.Add($truncationMsg)
                     break
                 }
             }

--- a/bin/release/monitor-release.ps1
+++ b/bin/release/monitor-release.ps1
@@ -64,7 +64,7 @@ $ErrorActionPreference = "Stop"
     near-duplicate blocks, and caps at a reasonable size.
 #>
 function Extract-MinimalErrors {
-    param([string[]]$LogLines)
+    param([string[]]$LogLines, [string]$RunId = '')
 
     $errorPatterns = @(
         'error:', 'Error:', 'ERROR:',
@@ -131,15 +131,20 @@ function Extract-MinimalErrors {
                 if (-not $prevWasSeparator -and $errors.Count -gt 0) {
                     $errors.Add("")
                 }
-                $errors.Add("══ block $($errors.Count / 2 + 1) ══")
+                $errors.Add("══ block $($seen.Count) ══")
                 $errors.Add($block)
                 $prevWasSeparator = $false
 
                 # Token safety: ~50 blocks max (≈200-300 lines)
                 if ($seen.Count -ge 50) {
                     $errors.Add("")
-                    $errors.Add("... (truncated at 50 blocks for token efficiency — run " +
-                                "`gh run view $RunId --log-failed` for full logs)")
+                    $truncationMsg = "... (truncated at 50 blocks for token efficiency"
+                    if ($RunId) {
+                        $truncationMsg += " — run `gh run view $RunId --log-failed` for full logs)"
+                    } else {
+                        $truncationMsg += " — use `gh run view --log-failed` for full logs)"
+                    }
+                    $errors.Add($truncationMsg)
                     break
                 }
             }


### PR DESCRIPTION
Fix two bugs in Extract-MinimalErrors: (1) block numbering formula produces fractional values breaking regex matching, (2) RunId variable undefined when called outside Invoke-WorkflowFailureHandler. See commit for details.