### PR TITLE
fix(test): replace stale coworker.ps1 entry with engineer.ps1

### DIFF
--- a/coworker/scripts/tests/coworker-scripts.ps1
+++ b/coworker/scripts/tests/coworker-scripts.ps1
@@ -1492,7 +1492,7 @@ $expectedScripts = @(
     'config.psd1',
     'coworker-scheduler.ps1',
     'coworker-scheduler.config.psd1',
-    'coworker.ps1',
+    'engineer.ps1',
     'process-coworker-queue.ps1',
     'process-draft-refinement-queue.ps1',
     'common\Util.ps1',


### PR DESCRIPTION
**Root cause:** `coworker/scripts/coworker.ps1` was deleted in commit `b3b38020b` ("refactor: remove useless files") and replaced by `engineer.ps1`. The test file's `expectedScripts` list was never updated and still referenced the deleted file.

**Fix:** Replace `'coworker.ps1'` → `'engineer.ps1'` in the expected scripts list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)