### PR TITLE
fix: resolve 3 e2e test failures (emoji type, press nav keys, swarm close)

### DIFF
--- a/browser4-agentic/src/main/kotlin/ai/platon/pulsar/agentic/tools/builtin/BrowserTabToolExecutor.kt
+++ b/browser4-agentic/src/main/kotlin/ai/platon/pulsar/agentic/tools/builtin/BrowserTabToolExecutor.kt
@@ -634,17 +634,19 @@ class BrowserTabToolExecutor : AbstractToolExecutor() {
                     (driver as PulsarWebDriver).autoDismissDialogs = true
                 }
                 try {
+                val button = args["button"]?.toString()
                 when {
                     args.containsKey("selector") && args.containsKey("count") && !args.containsKey("modifier") -> {
-                        validateArgs(args, allowed("selector", "count", "autoDismissDialogs"), setOf("selector", "count"), functionName)
+                        validateArgs(args, allowed("selector", "count", "button", "autoDismissDialogs"), setOf("selector", "count"), functionName)
                         driver.click(
                             selector = paramString(args, "selector", functionName)!!,
-                            count = paramInt(args, "count", functionName)!!
+                            count = paramInt(args, "count", functionName)!!,
+                            button = button,
                         )
                     }
 
                     args.containsKey("selector") && args.containsKey("modifier") && !args.containsKey("count") -> {
-                        validateArgs(args, allowed("selector", "modifier", "autoDismissDialogs"), setOf("selector", "modifier"), functionName)
+                        validateArgs(args, allowed("selector", "modifier", "button", "autoDismissDialogs"), setOf("selector", "modifier"), functionName)
                         driver.click(
                             selector = paramString(args, "selector", functionName)!!,
                             modifier = paramString(args, "modifier", functionName)!!
@@ -652,11 +654,11 @@ class BrowserTabToolExecutor : AbstractToolExecutor() {
                     }
 
                     args.containsKey("selector") && !args.containsKey("count") && !args.containsKey("modifier") -> {
-                        validateArgs(args, allowed("selector", "autoDismissDialogs"), setOf("selector"), functionName)
-                        driver.click(selector = paramString(args, "selector", functionName)!!)
+                        validateArgs(args, allowed("selector", "button", "autoDismissDialogs"), setOf("selector"), functionName)
+                        driver.click(selector = paramString(args, "selector", functionName)!!, button = button)
                     }
 
-                    else -> throw IllegalArgumentException("click requires 'selector' plus optionally one of 'count' or 'modifier'")
+                    else -> throw IllegalArgumentException("click requires 'selector' plus optionally one of 'count', 'modifier', or 'button'")
                 }
                 } finally {
                     if (wasAutoDismiss) {

--- a/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/api/BrowserProtocol.kt
+++ b/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/api/BrowserProtocol.kt
@@ -275,8 +275,8 @@ interface BrowserProtocol {
     fun onDragIntercepted(handler: (DragIntercepted) -> Unit): EventListener
 
     suspend fun dispatchMouseMoved(x: Double, y: Double, buttons: Int?, modifiers: Int? = null): Unit
-    suspend fun dispatchMousePressed(x: Double, y: Double, clickCount: Int, modifiers: Int?, buttons: Int): Unit
-    suspend fun dispatchMouseReleased(x: Double, y: Double, clickCount: Int, modifiers: Int?, buttons: Int): Unit
+    suspend fun dispatchMousePressed(x: Double, y: Double, clickCount: Int, modifiers: Int?, buttons: Int, button: String = "left"): Unit
+    suspend fun dispatchMouseReleased(x: Double, y: Double, clickCount: Int, modifiers: Int?, buttons: Int, button: String = "left"): Unit
     suspend fun dispatchMouseWheel(x: Double, y: Double, deltaX: Double, deltaY: Double, modifiers: Int? = null): Unit
 
     suspend fun setInterceptDrags(enabled: Boolean): Unit

--- a/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/api/WebDriver.kt
+++ b/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/api/WebDriver.kt
@@ -991,7 +991,7 @@ interface WebDriver : Closeable {
      * */
     @Throws(WebDriverException::class)
     @MCP
-    suspend fun click(selector: String, count: Int = 1)
+    suspend fun click(selector: String, count: Int = 1, button: String? = null)
 
     /**
      * Focus on an element with [selector] and click it with [modifier] pressed. @mcp

--- a/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/chrome/PulsarWebDriver.kt
+++ b/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/chrome/PulsarWebDriver.kt
@@ -1278,17 +1278,22 @@ open class PulsarWebDriver constructor(
         rpc.invokeOnElement(selector, "press") {
             val node = page.focusOnSelector(selector) ?: return@invokeOnElement
             emulator.click(node, 1, position = "right")
-            // Ensure the cursor is at the end of any existing text so that the
-            // pressed key appends rather than prepends.  CDP focus + click may
-            // leave the cursor at position 0 on some platforms.
-            try {
-                js.evaluate(
-                    "document.querySelector('${selector.replace("'", "\\'")}')" +
-                    ".setSelectionRange(99999, 99999)"
-                )
-            } catch (_: Exception) {
-                // Non-text elements (buttons, divs) don't support setSelectionRange.
-                // Silently ignore — the press will still work for non-text targets.
+            // For single printable characters, ensure the cursor is at the end of
+            // any existing text so typed chars append rather than prepend.  CDP
+            // focus + click may leave the cursor at position 0 on some platforms.
+            // Navigation keys (Home, Delete, ArrowLeft, etc.) must NOT reposition
+            // the cursor, or chained navigations like Home→Delete break: the second
+            // press would reset the cursor to end before dispatching the key.
+            if (key.length == 1 && !key[0].isISOControl()) {
+                try {
+                    js.evaluate(
+                        "document.querySelector('${selector.replace("'", "\\'")}')" +
+                        ".setSelectionRange(99999, 99999)"
+                    )
+                } catch (_: Exception) {
+                    // Non-text elements (buttons, divs) don't support setSelectionRange.
+                    // Silently ignore — the press will still work for non-text targets.
+                }
             }
             keyboard?.press(key, randomDelayMillis("press"))
             // CDP-dispatched Enter may not trigger implicit form submission (HTML spec §4.10.2.2).

--- a/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/chrome/PulsarWebDriver.kt
+++ b/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/chrome/PulsarWebDriver.kt
@@ -612,14 +612,28 @@ open class PulsarWebDriver constructor(
         rpc.invokeOnPage("mouseWheel") {
             // Primary: CDP mouse wheel — dispatches trusted wheel DOM events that
             // page listeners can observe (required for interactive fixtures).
-            // Fallback: JS window.scrollBy() when CDP fails (bypasses the
-            // Input.dispatchMouseEvent wheel race condition crbug.com/444929150).
+            // Fallback: JS window.scrollBy() + synthetic WheelEvent when CDP fails
+            // (bypasses the Input.dispatchMouseEvent wheel race condition
+            // crbug.com/444929150).  The synthetic WheelEvent ensures page
+            // listeners (e.g. the mouse fixture's wheelEvents tracker) observe
+            // the scroll.
             try {
                 withTimeout(wheelTimeout(deltaX, deltaY)) {
                     m.wheel(deltaX, deltaY)
                 }
             } catch (_: Exception) {
-                js.evaluate("window.scrollBy($deltaX, $deltaY)")
+                val x = m.currentX
+                val y = m.currentY
+                js.evaluate("""
+                    (function() {
+                        window.scrollBy($deltaX, $deltaY);
+                        window.dispatchEvent(new WheelEvent('wheel', {
+                            deltaX: $deltaX, deltaY: $deltaY, deltaMode: 0,
+                            clientX: $x, clientY: $y,
+                            bubbles: true, cancelable: true
+                        }));
+                    })()
+                """.trimIndent())
             }
         }
     }
@@ -634,14 +648,26 @@ open class PulsarWebDriver constructor(
                 // Primary: CDP mouse wheel — dispatches trusted wheel DOM events.
                 // Fallback: JS element.scrollBy() when CDP fails (bypasses the
                 // Input.dispatchMouseEvent wheel race condition crbug.com/444929150).
+                val m = mouse ?: return@invokeOnElement
                 try {
-                    val m = mouse ?: return@invokeOnElement
                     withTimeout(wheelTimeout(deltaX, deltaY)) {
                         m.moveTo(point, steps = 1)
                         m.wheel(deltaX, deltaY)
                     }
                 } catch (_: Exception) {
-                    js.evaluate("document.querySelector('${selector.replace("'", "\\'")}').scrollBy($deltaX, $deltaY)")
+                    val x = m.currentX
+                    val y = m.currentY
+                    js.evaluate("""
+                        (function() {
+                            var el = document.querySelector('${selector.replace("'", "\\'")}');
+                            if (el) { el.scrollBy($deltaX, $deltaY); }
+                            window.dispatchEvent(new WheelEvent('wheel', {
+                                deltaX: $deltaX, deltaY: $deltaY, deltaMode: 0,
+                                clientX: $x, clientY: $y,
+                                bubbles: true, cancelable: true
+                            }));
+                        })()
+                    """.trimIndent())
                 }
             }
         } catch (e: ChromeDriverException) {
@@ -754,12 +780,14 @@ open class PulsarWebDriver constructor(
         }
 
     @Throws(WebDriverException::class)
-    override suspend fun click(selector: String, count: Int) {
+    override suspend fun click(selector: String, count: Int, button: String?) {
         // Drain any stale dialog before clicking — a leftover dialog from a
         // previous operation would block CDP health checks and deadlock the
         // current click.  DialogHandler handles the deferral/no-op when the
         // queue is empty.
         dialogHandler.dismissAllPending()
+
+        val isNonLeftButton = button != null && button.lowercase() != "left"
 
         rpc.invokeOnElement(selector, "click", scrollIntoView = true) { node ->
             waitForScrollSettled(selector)
@@ -768,7 +796,10 @@ open class PulsarWebDriver constructor(
             // does not reliably trigger DOM click events in headless Chrome.
             // Use a DOM click as the sole mechanism (skip CDP mouse events to
             // avoid double-firing).  On Linux/macOS the CDP path works reliably.
-            if (isWindows) {
+            //
+            // Non-left clicks (right, middle) must always go through CDP because
+            // HTMLElement.click() dispatches left-click events only.
+            if (isWindows && !isNonLeftButton) {
                 emulator.click(
                     node, count, position = "center", modifier = null,
                     delayMillis = 0, dispatchCdpMouseEvents = false,
@@ -776,7 +807,7 @@ open class PulsarWebDriver constructor(
                 dispatchDomClick(node, count)
             } else {
                 val delayMillis = randomDelayMillis("click")
-                emulator.click(node, count, position = "center", modifier = null, delayMillis = delayMillis)
+                emulator.click(node, count, position = "center", modifier = null, delayMillis = delayMillis, button = button)
             }
         }
 
@@ -917,6 +948,11 @@ open class PulsarWebDriver constructor(
                                emitClick(this, cx, cy, detail);
                              }
                              function emitClick(el, cx, cy, d) {
+                               // Explicitly focus the element before the click
+                               // sequence so that focus events fire reliably even
+                               // in headless Chrome where HTMLElement.click() may
+                               // not trigger implicit focus.
+                               if (typeof el.focus === 'function') { el.focus(); }
                                var ptr = new PointerEvent('pointerdown', {bubbles:true,cancelable:true,view:window,pointerId:1,pointerType:'mouse',isPrimary:true,clientX:cx,clientY:cy,buttons:1,button:0,detail:d});
                                var md  = new MouseEvent('mousedown', {bubbles:true,cancelable:true,view:window,clientX:cx,clientY:cy,buttons:1,button:0,detail:d});
                                el.dispatchEvent(ptr);
@@ -945,6 +981,11 @@ open class PulsarWebDriver constructor(
                                this.dispatchEvent(new MouseEvent('dblclick', {bubbles:true,cancelable:true,view:window,detail:2}));
                              }
                              function emitClick(el, cx, cy, d) {
+                               // Explicitly focus the element before the click
+                               // sequence so that focus events fire reliably even
+                               // in headless Chrome where HTMLElement.click() may
+                               // not trigger implicit focus.
+                               if (typeof el.focus === 'function') { el.focus(); }
                                var ptr = new PointerEvent('pointerdown', {bubbles:true,cancelable:true,view:window,pointerId:1,pointerType:'mouse',isPrimary:true,clientX:cx,clientY:cy,buttons:1,button:0,detail:d});
                                var md  = new MouseEvent('mousedown', {bubbles:true,cancelable:true,view:window,clientX:cx,clientY:cy,buttons:1,button:0,detail:d});
                                el.dispatchEvent(ptr);
@@ -1193,6 +1234,10 @@ open class PulsarWebDriver constructor(
             browserProtocol.callFunctionOn(
                 """function(text) {
                     if (typeof this.focus === 'function') { this.focus(); }
+                    // Respect HTML maxlength constraint — the browser enforces it
+                    // for user input but not for programmatic value assignment.
+                    var maxLen = this.maxLength;
+                    if (maxLen > 0 && text.length > maxLen) { text = text.substring(0, maxLen); }
                     this.value = text;
                     this.dispatchEvent(new Event('input', { bubbles: true }));
                     this.dispatchEvent(new Event('change', { bubbles: true }));

--- a/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/chrome/protocol/DirectChromeProtocol.kt
+++ b/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/chrome/protocol/DirectChromeProtocol.kt
@@ -734,7 +734,7 @@ class DirectChromeProtocol(
     }
 
     override suspend fun dispatchMousePressed(
-        x: Double, y: Double, clickCount: Int, modifiers: Int?, buttons: Int
+        x: Double, y: Double, clickCount: Int, modifiers: Int?, buttons: Int, button: String
     ) {
         command(
             "Input.dispatchMouseEvent",
@@ -742,7 +742,7 @@ class DirectChromeProtocol(
                 put("type", DispatchMouseEventType.MOUSE_PRESSED)
                 put("x", x)
                 put("y", y)
-                put("button", MouseButton.LEFT)
+                put("button", button)
                 modifiers?.let { put("modifiers", it) }
                 put("buttons", buttons)
                 put("clickCount", clickCount)
@@ -752,7 +752,7 @@ class DirectChromeProtocol(
     }
 
     override suspend fun dispatchMouseReleased(
-        x: Double, y: Double, clickCount: Int, modifiers: Int?, buttons: Int
+        x: Double, y: Double, clickCount: Int, modifiers: Int?, buttons: Int, button: String
     ) {
         command(
             "Input.dispatchMouseEvent",
@@ -760,7 +760,7 @@ class DirectChromeProtocol(
                 put("type", DispatchMouseEventType.MOUSE_RELEASED)
                 put("x", x)
                 put("y", y)
-                put("button", MouseButton.LEFT)
+                put("button", button)
                 put("clickCount", clickCount)
                 modifiers?.let { put("modifiers", it) }
                 put("buttons", buttons)

--- a/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/chrome/protocol/EmulationHandler.kt
+++ b/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/chrome/protocol/EmulationHandler.kt
@@ -217,24 +217,34 @@ class Mouse(private val bp: BrowserProtocol) {
     var currentX = 0.0
     var currentY = 0.0
 
-    // Track current pressed buttons bitfield. For left button only, we use 1 as Chromium does.
+    // Track current pressed buttons bitfield.
+    // 1=left, 2=right, 4=middle.
     private var buttonsState: Int = 0
+
+    /** Map button name to (cdpButtonName, bitmask). */
+    private fun buttonInfo(button: String?): Pair<String, Int> = when (button?.lowercase()) {
+        "right" -> "right" to 2
+        "middle" -> "middle" to 4
+        else -> "left" to 1
+    }
 
     /**
      * Shortcut for `mouse.move`, `mouse.down` and `mouse.up`.
      * @param x - Horizontal position of the mouse.
      * @param y - Vertical position of the mouse.
+     * @param button - Mouse button name: "left", "right", or "middle" (default "left").
      */
-    suspend fun click(x: Double, y: Double, clickCount: Int = 1, modifiers: Int? = null, delayMillis: Long = 500) {
+    suspend fun click(x: Double, y: Double, clickCount: Int = 1, modifiers: Int? = null, delayMillis: Long = 500, button: String? = null) {
+        val (cdpButton, buttonMask) = buttonInfo(button)
         moveTo(x, y)
 
         // Proper multi-click semantics: for each click i, use clickCount=i on press/release
         for (cc in 1..max(1, clickCount)) {
-            down(x, y, cc, modifiers)
+            down(x, y, cc, modifiers, buttonMask = buttonMask, cdpButton = cdpButton)
             if (delayMillis > 0) {
                 delay(delayMillis.milliseconds)
             }
-            up(x, y, cc, modifiers)
+            up(x, y, cc, modifiers, buttonMask = buttonMask, cdpButton = cdpButton)
             if (cc < clickCount && delayMillis > 0) {
                 delay(delayMillis.milliseconds)
             }
@@ -277,15 +287,15 @@ class Mouse(private val bp: BrowserProtocol) {
     /**
      * Dispatches a `mousedown` event.
      */
-    suspend fun down(clickCount: Int = 1, modifiers: Int? = null) {
-        down(currentX, currentY, clickCount, modifiers)
+    suspend fun down(clickCount: Int = 1, modifiers: Int? = null, buttonMask: Int = 1, cdpButton: String = "left") {
+        down(currentX, currentY, clickCount, modifiers, buttonMask = buttonMask, cdpButton = cdpButton)
     }
 
     /**
      * Dispatches a `mousedown` event.
      */
-    suspend fun down(point: PointD, clickCount: Int = 1, modifiers: Int? = null) {
-        down(point.x, point.y, clickCount, modifiers)
+    suspend fun down(point: PointD, clickCount: Int = 1, modifiers: Int? = null, buttonMask: Int = 1, cdpButton: String = "left") {
+        down(point.x, point.y, clickCount, modifiers, buttonMask = buttonMask, cdpButton = cdpButton)
     }
 
     /**
@@ -295,31 +305,33 @@ class Mouse(private val bp: BrowserProtocol) {
      * @param y Y coordinate
      * @param modifiers Bit field representing pressed modifier keys. Alt=1, Ctrl=2, Meta/Command=4, Shift=8
      * * (default: 0).
+     * @param buttonMask Button bitmask to add to buttonsState (1=left, 2=right, 4=middle).
+     * @param cdpButton CDP button name to report in the event (MouseButton.LEFT/RIGHT/MIDDLE).
      */
-    suspend fun down(x: Double, y: Double, clickCount: Int = 1, modifiers: Int? = null) {
+    suspend fun down(x: Double, y: Double, clickCount: Int = 1, modifiers: Int? = null, buttonMask: Int = 1, cdpButton: String = "left") {
         currentX = x
         currentY = y
 
-        // Update buttons bitfield to include left button (1)
-        buttonsState = buttonsState or 1
-        bp.dispatchMousePressed(x, y, clickCount, modifiers, buttonsState)
+        // Update buttons bitfield to include the pressed button
+        buttonsState = buttonsState or buttonMask
+        bp.dispatchMousePressed(x, y, clickCount, modifiers, buttonsState, button = cdpButton)
     }
 
-    suspend fun up() {
-        up(currentX, currentY)
+    suspend fun up(buttonMask: Int = 1, cdpButton: String = "left") {
+        up(currentX, currentY, buttonMask = buttonMask, cdpButton = cdpButton)
     }
 
-    suspend fun up(point: PointD) {
-        up(point.x, point.y)
+    suspend fun up(point: PointD, buttonMask: Int = 1, cdpButton: String = "left") {
+        up(point.x, point.y, buttonMask = buttonMask, cdpButton = cdpButton)
     }
 
-    suspend fun up(x: Double, y: Double, clickCount: Int = 1, modifiers: Int? = null) {
+    suspend fun up(x: Double, y: Double, clickCount: Int = 1, modifiers: Int? = null, buttonMask: Int = 1, cdpButton: String = "left") {
         currentX = x
         currentY = y
 
-        // Update buttons bitfield to reflect release of left button
-        buttonsState = buttonsState and 1.inv()
-        bp.dispatchMouseReleased(x, y, clickCount, modifiers, buttonsState)
+        // Update buttons bitfield to reflect release of the button
+        buttonsState = buttonsState and buttonMask.inv()
+        bp.dispatchMouseReleased(x, y, clickCount, modifiers, buttonsState, button = cdpButton)
     }
 
     /**
@@ -782,6 +794,7 @@ class EmulationHandler(
         count: Int,
         position: String = "center",
         modifier: String? = null,
+        button: String? = null,
         delayMillis: Long = 100,
         dispatchCdpMouseEvents: Boolean = true,
     ) {
@@ -804,12 +817,16 @@ class EmulationHandler(
             }
         }
 
+        // Non-left clicks (right, middle) must always go through CDP because
+        // DOM HTMLElement.click() dispatches left-click events only.
+        val isNonLeftButton = button != null && button.lowercase() != "left"
+
         // On Windows, CDP Input.dispatchMouseEvent does not reliably trigger
         // DOM click events in headless Chrome.  When dispatchCdpMouseEvents is
         // false (Windows-only), the caller will use a DOM click fallback instead.
         // We still run the prep work above (point calculation + focus) so the
         // element is ready for interaction.
-        if (!dispatchCdpMouseEvents) {
+        if (!dispatchCdpMouseEvents && !isNonLeftButton) {
             return
         }
 
@@ -821,7 +838,7 @@ class EmulationHandler(
         if (modifier != null) {
             clickWithModifiers(point, modifier, count, delayMillis = delayMillis)
         } else {
-            mouse?.click(point.x, point.y, count, delayMillis = delayMillis)
+            mouse?.click(point.x, point.y, count, delayMillis = delayMillis, button = button)
         }
     }
 

--- a/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/chrome/protocol/EmulationHandler.kt
+++ b/browser4-core/browser4-browser/src/main/kotlin/ai/platon/browser4/chrome/protocol/EmulationHandler.kt
@@ -501,16 +501,22 @@ class Keyboard(private val bp: BrowserProtocol) {
     private val pressedKeys = mutableSetOf<String>()
 
     suspend fun type(text: String, delayMillis: Long) {
-        text.forEach { char ->
-            if (Character.isISOControl(char)) {
-                press("$char", delayMillis)
+        var i = 0
+        while (i < text.length) {
+            val codePoint = text.codePointAt(i)
+            val charCount = Character.charCount(codePoint)
+            val charString = text.substring(i, i + charCount)
+
+            if (Character.isISOControl(codePoint)) {
+                press(charString, delayMillis)
             } else {
-                bp.insertText("$char")
+                bp.insertText(charString)
             }
 
             if (delayMillis > 0) {
                 delay(delayMillis.milliseconds)
             }
+            i += charCount
         }
     }
 

--- a/browser4-rest/src/main/kotlin/ai/platon/pulsar/rest/mcp/controller/ArgumentNormalizers.kt
+++ b/browser4-rest/src/main/kotlin/ai/platon/pulsar/rest/mcp/controller/ArgumentNormalizers.kt
@@ -48,7 +48,7 @@ class DefaultArgumentNormalizer : ArgumentNormalizer {
                 }
             }
         }
-        
+
         return args
     }
     

--- a/cli/browser4-cli/tests/e2e/scenarios/mock_server.rs
+++ b/cli/browser4-cli/tests/e2e/scenarios/mock_server.rs
@@ -3264,7 +3264,7 @@ pub(super) fn test_swarm_close_session(ctx: &mut E2ECtx) {
     let close_result = run_command(ctx, &["swarm", "close"]);
     let close_output = strip_snapshot_output(&close_result.stdout);
     assert!(
-        close_output.contains("Session closed") || close_output.contains("SWARM"),
+        close_output.contains("session closed") || close_output.contains("Swarm"),
         "Expected session-close confirmation in:\n{}",
         close_result.stdout
     );


### PR DESCRIPTION
## Summary

Fixes all 9 e2e test failures from the extended test suite.

## Changes

### Fix 1 — Handle Unicode surrogate pairs in `Keyboard.type()` (test 4)
`Keyboard.type()` iterated by UTF-16 `Char` which splits surrogate pairs (e.g. 🎉 U+1F389 → two chars). Each half was sent to CDP `Input.insertText` as invalid text, causing `Unexpected error in [type]`. Switched to code-point iteration using `String.codePointAt()`.

### Fix 2 — Conditional cursor-to-end in `press()` for navigation keys (test 5)
`PulsarWebDriver.press()` always called `setSelectionRange(99999, 99999)` before each key press. This broke chained navigation keys like Home→Delete: Home moves cursor to 0, but the next press call resets cursor to end before dispatching Delete (nothing after cursor to delete). Now only repositions cursor for single printable characters.

### Fix 3 — Update swarm close session test assertion (test 9)
Commit `49ae4c93f` changed CLI output from "Session closed" to "Swarm session closed". Updated test assertion.

### Fix 4 — Implement right-click CDP support (tests 1, 3, 8)
Added `button` parameter through the entire click dispatch chain: `BrowserProtocol` → `DirectChromeProtocol` → `Mouse` → `EmulationHandler` → `PulsarWebDriver` → `BrowserTabToolExecutor`. On Windows, right-click bypasses the DOM-only path (which can only dispatch left-click events) and forces CDP.

### Fix 5 — Dispatch synthetic WheelEvent in mouseWheel JS fallback (test 2)
When CDP `mouseWheel` times out (crbug.com/444929150), the `scrollBy()` fallback now also dispatches a synthetic `WheelEvent` so page listeners observe the scroll.

### Fix 6 — Respect HTML maxlength in fill JS fallback (test 6)
`setValueViaJs()` now truncates the value to `element.maxLength` before assignment, matching browser behavior for user input.

### Fix 7 — Explicit focus in DOM click path (test 7)
Added `el.focus()` call in `emitClick()` before the click sequence on Windows, so focus events fire reliably in headless Chrome.

## Why CI didn't catch these

- **CI pipeline** (`ci.yml`) runs only `ScenarioLevel::Basic` tests — all 9 failing scenarios except `test_e2e_swarm_close_session` are `ScenarioLevel::Extended`
- **CI triggers** only on CI-tagged releases (`v*-ci.*`), not regular pushes/PRs
- **Nightly pipeline** (`nightly.yml`) runs Extended tests daily at midnight, but the breaking commits (July 18–31) may not have been caught in a nightly run yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)