### PR TITLE
fix: resolve PowerShell parser error with  in monitor-release.ps1

### DIFF
--- a/bin/release/monitor-release.ps1
+++ b/bin/release/monitor-release.ps1
@@ -367,7 +367,7 @@ function Get-ReleaseChangelog {
             $log = git log --oneline "$prevTag..$Tag" -- . 2>&1
             if ($log -and $LASTEXITCODE -eq 0) {
                 Pop-Location
-                return "Commits since $prevTag:`n$log"
+                return "Commits since ${prevTag}:`n$log"
             }
         }
 


### PR DESCRIPTION
## Problem

Running `bin/release/monitor-release.ps1` fails with a PowerShell parser error on line 370:

```
ParserError: Variable reference is not valid. ':' was not followed by a valid variable name character. Consider using ${} to delimit the name.
```

## Fix

Wrapped `prevTag` in `${}` to delimit the variable name from the colon character:

```diff
- return "Commits since $prevTag:`n$log"
+ return "Commits since ${prevTag}:`n$log"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)