### PR TITLE
feat(mcp): add MCP-over-HTTP (SSE) transport support

### DIFF
--- a/browser4-agentic/pom.xml
+++ b/browser4-agentic/pom.xml
@@ -98,6 +98,19 @@
             <version>${mcp-sdk.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Ktor CIO engine for embedded MCP HTTP server (lightweight, pure Kotlin) -->
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-server-cio-jvm</artifactId>
+            <version>3.2.3</version>
+        </dependency>
+        <!-- Ktor client CIO engine for MCP HTTP E2E tests -->
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-cio-jvm</artifactId>
+            <version>3.2.3</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Observability: OpenTelemetry for distributed tracing (optional) -->
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/browser4-agentic/src/main/kotlin/ai/platon/pulsar/agentic/mcp/server/Browser4MCPServerRunner.kt
+++ b/browser4-agentic/src/main/kotlin/ai/platon/pulsar/agentic/mcp/server/Browser4MCPServerRunner.kt
@@ -8,70 +8,192 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.io.asSink
 import kotlinx.io.asSource
 import kotlinx.io.buffered
+import java.util.concurrent.CountDownLatch
 
 /**
- * Starts the Browser4 MCP server using STDIO transport.
+ * Starts the Browser4 MCP server.
  *
- * STDIO transport is the standard integration method used by Claude Desktop,
- * Cursor, Windsurf, and other MCP-compatible AI clients that launch the server
- * as a local subprocess and communicate via stdin/stdout.
+ * Two transports are supported:
+ *
+ * - **STDIO** (default) — standard integration used by Claude Desktop, Cursor,
+ *   Windsurf, and other MCP-compatible AI clients that launch the server as a
+ *   local subprocess and communicate via stdin/stdout.
+ * - **HTTP** (SSE) — for remote MCP clients that connect over HTTP.  The server
+ *   listens on a configurable port and exposes `/mcp/sse` (GET, SSE stream) and
+ *   `/mcp/message` (POST, JSON-RPC).
  *
  * ## Usage
  *
- * ### Direct invocation
  * ```bash
+ * # STDIO (default)
  * java -jar Browser4.jar --app mcp
+ *
+ * # HTTP (SSE transport)
+ * java -jar Browser4.jar --app mcp --transport http
+ * java -jar Browser4.jar --app mcp --transport http --port 8088
+ *
+ * # Enable headless mode (either transport)
+ * java -jar Browser4.jar --app mcp --headless
  * ```
  *
- * ### Claude Desktop configuration (`claude_desktop_config.json`)
+ * ## Claude Desktop configuration (`claude_desktop_config.json`)
+ *
+ * ### STDIO transport
  * ```json
  * {
  *   "mcpServers": {
  *     "browser4": {
  *       "command": "java",
- *       "args": ["-jar", "/path/to/Browser4.jar", "--app", "mcp"],
+ *       "args": ["-jar", "/path/to/Browser4.jar", "--app", "mcp"]
  *     }
  *   }
  * }
  * ```
  *
- * ## Behaviour
- * 1. Creates an [ai.platon.pulsar.agentic.AgenticSession] and acquires a companion [BasicBrowserAgent].
- * 2. Wraps the agent's [ai.platon.pulsar.agentic.tools.AgentToolManager] in a [Browser4MCPServer],
- *    which discovers and registers all tools from the manager.
- * 3. Creates a [StdioServerTransport] that reads JSON-RPC messages from stdin
- *    and writes responses to stdout.
- * 4. Blocks until the MCP client closes the connection (i.e. EOF on stdin).
- * 5. Shuts down the Pulsar context and closes the browser.
+ * ### HTTP transport
+ * ```json
+ * {
+ *   "mcpServers": {
+ *     "browser4": {
+ *       "type": "streamableHttp",
+ *       "url": "http://localhost:8088/mcp/sse"
+ *     }
+ *   }
+ * }
+ * ```
  */
 fun runBrowser4MCPServer(args: Array<String> = emptyArray()) {
-    require(args.isEmpty()) {
-        "MCP mode does not accept application arguments: ${args.joinToString(" ")}"
+    val logger = getLogger("Browser4MCPServerRunner")
+
+    // Parse options
+    var transport = "stdio"
+    var port = McpHttpServer.DEFAULT_MCP_HTTP_PORT
+    var headless = false
+
+    var i = 0
+    while (i < args.size) {
+        when (args[i]) {
+            "--transport" -> {
+                if (i + 1 < args.size) {
+                    transport = args[++i].lowercase()
+                }
+            }
+            "--port" -> {
+                if (i + 1 < args.size) {
+                    port = args[++i].toIntOrNull() ?: McpHttpServer.DEFAULT_MCP_HTTP_PORT
+                }
+            }
+            "--headless" -> headless = true
+            "--help", "-h" -> {
+                printUsage()
+                return
+            }
+            else -> {
+                System.err.println("Unknown option: ${args[i]}")
+                printUsage()
+                return
+            }
+        }
+        i++
     }
 
-    val logger = getLogger("Browser4MCPServerRunner")
-    logger.info("Starting Browser4 MCP Server (STDIO transport)")
+    require(transport in setOf("stdio", "http")) {
+        "Unknown transport: $transport (expected 'stdio' or 'http')"
+    }
 
-    val session = AgenticContexts.createSession()
-    val agent = session.companionAgent as BasicBrowserAgent
-
-    try {
-        val mcpServer = Browser4MCPServer(toolManager = agent.agentToolManager)
-
-        val transport = StdioServerTransport(
-            inputStream = System.`in`.asSource().buffered(),
-            outputStream = System.out.asSink().buffered()
+    // Create session and acquire the agent
+    val session = AgenticContexts.createSession(headless = headless)
+    val agent = session.companionAgent as? BasicBrowserAgent
+        ?: throw IllegalStateException(
+            "MCP server requires a BasicBrowserAgent, but companion agent is ${session.companionAgent::class.simpleName}"
         )
 
-        runBlocking {
-            logger.info("Browser4 MCP Server connected — waiting for client requests")
-            mcpServer.server.connect(transport)
-            logger.info("Browser4 MCP Server STDIO session ended")
+    try {
+        when (transport) {
+            "stdio" -> runStdioServer(logger, agent)
+            "http" -> runHttpServer(logger, agent, port)
         }
     } finally {
         logger.info("Shutting down Browser4 MCP Server")
         AgenticContexts.shutdown()
     }
+}
+
+// ---------------------------------------------------------------------------
+// Transport implementations
+// ---------------------------------------------------------------------------
+
+private fun runStdioServer(logger: org.slf4j.Logger, agent: BasicBrowserAgent) {
+    logger.info("Starting Browser4 MCP Server (STDIO transport)")
+
+    val mcpServer = Browser4MCPServer(toolManager = agent.agentToolManager)
+    val transport = StdioServerTransport(
+        inputStream = System.`in`.asSource().buffered(),
+        outputStream = System.out.asSink().buffered(),
+    )
+
+    runBlocking {
+        logger.info("Browser4 MCP Server connected — waiting for client requests")
+        mcpServer.server.connect(transport)
+        logger.info("Browser4 MCP Server STDIO session ended")
+    }
+}
+
+private fun runHttpServer(logger: org.slf4j.Logger, agent: BasicBrowserAgent, port: Int) {
+    logger.info("Starting Browser4 MCP Server (HTTP/SSE transport on port {})", port)
+
+    val server = McpHttpServer(
+        toolManager = agent.agentToolManager,
+        port = port,
+    )
+    server.start()
+
+    logger.info(
+        "Browser4 MCP HTTP Server listening on http://localhost:{}/mcp/sse",
+        port,
+    )
+
+    // Block until the JVM is terminated (SIGTERM / Ctrl+C).
+    // The CountDownLatch never counts down — the JVM exit will interrupt it.
+    try {
+        CountDownLatch(1).await()
+    } catch (_: InterruptedException) {
+        // Shutdown signal received.
+    } finally {
+        server.stop()
+    }
+
+    logger.info("Browser4 MCP HTTP Server session ended")
+}
+
+// ---------------------------------------------------------------------------
+// Help
+// ---------------------------------------------------------------------------
+
+private fun printUsage() {
+    System.err.println(
+        """
+        |Browser4 MCP Server
+        |
+        |Usage: java -jar Browser4.jar --app mcp [options]
+        |
+        |Transport options:
+        |  --transport stdio    STDIO transport (default) — for local MCP clients
+        |  --transport http     HTTP/SSE transport — for remote MCP clients
+        |
+        |HTTP options (only with --transport http):
+        |  --port <n>           Listen port (default: 8088)
+        |
+        |General options:
+        |  --headless           Run Chrome in headless mode
+        |  --help, -h           Print this help
+        |
+        |Examples:
+        |  java -jar Browser4.jar --app mcp
+        |  java -jar Browser4.jar --app mcp --transport http --port 8088
+        |  java -jar Browser4.jar --app mcp --headless
+        """.trimMargin()
+    )
 }
 
 fun main(args: Array<String>) = runBrowser4MCPServer(args)

--- a/browser4-agentic/src/main/kotlin/ai/platon/pulsar/agentic/mcp/server/McpHttpServer.kt
+++ b/browser4-agentic/src/main/kotlin/ai/platon/pulsar/agentic/mcp/server/McpHttpServer.kt
@@ -1,0 +1,212 @@
+package ai.platon.pulsar.agentic.mcp.server
+
+import ai.platon.pulsar.agentic.tools.AgentToolManager
+import ai.platon.pulsar.common.getLogger
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.RoutingContext
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.sse.SSE
+import io.ktor.server.sse.ServerSSESession
+import io.ktor.server.sse.sse
+import io.modelcontextprotocol.kotlin.sdk.server.SseServerTransport
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * An embedded Ktor HTTP server that exposes Browser4's MCP tools via the standard
+ * MCP Streamable HTTP (SSE) transport.
+ *
+ * This is the HTTP counterpart to [Browser4MCPServerRunner]'s STDIO transport.
+ * It allows external MCP clients (Claude Desktop, Cursor, Windsurf, etc.) to
+ * connect to Browser4 over HTTP instead of requiring a local subprocess.
+ *
+ * ## Protocol
+ *
+ * - **GET  /mcp/sse** — establishes an SSE stream for server→client messages.
+ *   The server responds with an `endpoint` event containing the session-scoped
+ *   POST URL.
+ * - **POST /mcp/message?sessionId=...** — client→server JSON-RPC messages.
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val server = McpHttpServer(toolManager, port = 8088)
+ * server.start()
+ * // ... MCP clients connect to http://localhost:8088/mcp/sse
+ * server.stop()
+ * ```
+ *
+ * ## Spring Boot integration
+ *
+ * See [McpHttpServerConfiguration] in browser4-rest for auto-configuration that
+ * starts this server as part of the Browser4 Spring Boot application lifecycle.
+ *
+ * @param toolManager The [AgentToolManager] providing browser automation tools.
+ * @param port The port to listen on (default 8088).
+ * @param host The hostname to bind to (default "0.0.0.0").
+ * @param serverInfo MCP server identification for the initialize handshake.
+ */
+class McpHttpServer(
+    private val toolManager: AgentToolManager,
+    private val port: Int = DEFAULT_MCP_HTTP_PORT,
+    private val host: String = "0.0.0.0",
+    serverInfo: Implementation = Implementation(name = "browser4-mcp-server", version = "1.0.0"),
+) {
+    companion object {
+        /** Default port for the MCP HTTP server. */
+        const val DEFAULT_MCP_HTTP_PORT = 8088
+    }
+
+    private val logger = getLogger(this)
+
+    /** The shared Browser4 MCP server — one instance handles all client sessions. */
+    private val mcpServer = Browser4MCPServer(toolManager, serverInfo)
+
+    /** Tracks active SSE transports by session ID so POST requests can be routed. */
+    private val transports = ConcurrentHashMap<String, SseServerTransport>()
+
+    private var engine: EmbeddedServer<*, *>? = null
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    /**
+     * Start the embedded Ktor HTTP server.
+     *
+     * This method returns immediately; the server runs on its own event-loop thread.
+     * Call [stop] to shut it down.
+     */
+    fun start() {
+        logger.info("Starting MCP HTTP server on {}:{}", host, port)
+
+        engine = embeddedServer(CIO, port = port, host = host) {
+            install(SSE)
+
+            routing {
+                route("/mcp") {
+                    // SSE endpoint — each GET establishes a new SSE stream for
+                    // server→client messages (tools/list responses, tool call
+                    // results, notifications).
+                    sse("/sse") {
+                        onSseConnect(this@McpHttpServer, this)
+                    }
+
+                    // POST endpoint — client→server JSON-RPC messages.
+                    post("/message") {
+                        onPostMessage(this)
+                    }
+                }
+            }
+        }.start(wait = false)
+
+        logger.info("MCP HTTP server listening on http://{}:{}/mcp/sse", host, port)
+    }
+
+    /**
+     * Stop the embedded Ktor server, closing all active SSE connections.
+     */
+    fun stop() {
+        logger.info("Stopping MCP HTTP server ({} active sessions)", transports.size)
+        transports.values.forEach { transport ->
+            runCatching { runBlocking { transport.close() } }
+        }
+        transports.clear()
+        engine?.stop(gracePeriodMillis = 3000L, timeoutMillis = 5000L)
+        engine = null
+        logger.info("MCP HTTP server stopped")
+    }
+
+    /** Returns the number of active MCP client sessions. */
+    val activeSessions: Int get() = transports.size
+
+    // -------------------------------------------------------------------------
+    // Internal — SSE connection lifecycle
+    // -------------------------------------------------------------------------
+
+    /**
+     * Handle a new SSE connection from a client.
+     *
+     * 1. Creates an [SseServerTransport] wrapping the Ktor [ServerSSESession]
+     * 2. Registers it so POST requests can find it by session ID
+     * 3. Connects the transport to [mcpServer] via [Browser4MCPServer.server.createSession]
+     * 4. Blocks until the SSE stream is closed by the client
+     */
+    private suspend fun onSseConnect(server: McpHttpServer, sseSession: ServerSSESession) {
+        val transport = SseServerTransport(
+            endpoint = "/message",
+            session = sseSession,
+        )
+
+        server.transports[transport.sessionId] = transport
+        server.logger.info(
+            "MCP SSE connection established: sessionId={} (total={})",
+            transport.sessionId,
+            server.transports.size,
+        )
+
+        try {
+            // createSession() calls transport.start() which sends the endpoint
+            // event to the client, then handles the initialize handshake.
+            server.mcpServer.server.createSession(transport)
+            // Block until the SSE stream ends (client disconnects or error).
+            awaitCancellation()
+        } catch (_: CancellationException) {
+            // Normal SSE disconnect — the client closed the connection.
+        } catch (e: Exception) {
+            server.logger.warn(
+                "MCP SSE session error: sessionId={} | {}",
+                transport.sessionId,
+                e.message,
+            )
+        } finally {
+            server.transports.remove(transport.sessionId)
+            runCatching { transport.close() }
+            server.logger.info(
+                "MCP SSE connection closed: sessionId={} (total={})",
+                transport.sessionId,
+                server.transports.size,
+            )
+        }
+    }
+
+    /**
+     * Handle a POST request containing a JSON-RPC message from the client.
+     *
+     * The request must include a `sessionId` query parameter so we can locate
+     * the corresponding SSE transport.
+     */
+    private suspend fun onPostMessage(ctx: RoutingContext) {
+        // queryParameters is a member property on ApplicationRequest, accessed
+        // via ctx.call.request — no explicit import needed.
+        val sessionId = ctx.call.request.queryParameters["sessionId"]
+        if (sessionId.isNullOrBlank()) {
+            ctx.call.respondText(
+                text = "Missing 'sessionId' query parameter",
+                status = HttpStatusCode.BadRequest,
+            )
+            return
+        }
+
+        val transport = transports[sessionId]
+        if (transport == null) {
+            ctx.call.respondText(
+                text = "Session not found: $sessionId",
+                status = HttpStatusCode.NotFound,
+            )
+            return
+        }
+
+        transport.handlePostMessage(ctx.call)
+    }
+}

--- a/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/mcp/server/McpHttpServerE2ETest.kt
+++ b/browser4-agentic/src/test/kotlin/ai/platon/pulsar/agentic/mcp/server/McpHttpServerE2ETest.kt
@@ -1,0 +1,271 @@
+package ai.platon.pulsar.agentic.mcp.server
+
+import ai.platon.pulsar.agentic.model.TcEvaluate
+import ai.platon.pulsar.agentic.model.ToolCallResult
+import ai.platon.pulsar.agentic.model.ToolSpec
+import ai.platon.pulsar.agentic.tools.AgentToolManager
+import ai.platon.pulsar.agentic.tools.builtin.ToolExecutor
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.sse.SSE
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.modelcontextprotocol.kotlin.sdk.client.Client
+import io.modelcontextprotocol.kotlin.sdk.client.SseClientTransport
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import java.net.ServerSocket
+
+/**
+ * End-to-end tests for [McpHttpServer] over the MCP Streamable HTTP protocol.
+ *
+ * These tests:
+ * 1. Start an [McpHttpServer] on a random available port with a mocked
+ *    [AgentToolManager] (no real browser).
+ * 2. Connect an MCP [Client] via [StreamableHttpClientTransport] over a
+ *    Ktor CIO HTTP client.
+ * 3. Verify `tools/list` and `tools/call` through the full protocol stack:
+ *    HTTP → SSE → JSON-RPC → [Browser4MCPServer] → [AgentToolManager].
+ */
+@Tag("mcp")
+@DisplayName("McpHttpServer E2E (full MCP Streamable HTTP protocol)")
+class McpHttpServerE2ETest {
+
+    private lateinit var toolManager: AgentToolManager
+    private lateinit var mcpHttpServer: McpHttpServer
+    private lateinit var client: Client
+    private lateinit var httpClient: HttpClient
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var testPort: Int = 0
+
+    @BeforeEach
+    fun setUp() {
+        runBlocking {
+
+        // Find an available port
+        testPort = ServerSocket(0).use { it.localPort }
+
+        // Set up driver executor with tool specs (same pattern as Browser4MCPServerE2ETest)
+        val driverExecutor: ToolExecutor = mockk(relaxed = true)
+        every { driverExecutor.domain } returns "tab"
+        every { driverExecutor.getToolSpecs() } returns mapOf(
+            "navigate" to ToolSpec("tab", "navigate",
+                listOf(ToolSpec.Arg("url", "String", null)), "Unit",
+                "Navigate the browser to a URL."),
+            "reload" to ToolSpec("tab", "reload",
+                emptyList(), "Unit", "Reload the current page."),
+            "goBack" to ToolSpec("tab", "goBack",
+                emptyList(), "Unit", "Navigate back."),
+            "goForward" to ToolSpec("tab", "goForward",
+                emptyList(), "Unit", "Navigate forward."),
+            "click" to ToolSpec("tab", "click",
+                listOf(ToolSpec.Arg("selector", "String", null)), "Unit",
+                "Click an element."),
+            "fill" to ToolSpec("tab", "fill",
+                listOf(ToolSpec.Arg("selector", "String", null), ToolSpec.Arg("text", "String", null)),
+                "Unit", "Fill an input."),
+            "getText" to ToolSpec("tab", "getText",
+                listOf(ToolSpec.Arg("selector", "String", null)), "String?",
+                "Get element text."),
+            "evaluate" to ToolSpec("tab", "evaluate",
+                listOf(ToolSpec.Arg("expression", "String", null)), "Any?",
+                "Evaluate JavaScript."),
+        )
+
+        toolManager = mockk(relaxed = true)
+        every { toolManager.registeredExecutors } returns listOf(driverExecutor).associateBy { it.domain }
+
+        // Start the MCP HTTP server
+        mcpHttpServer = McpHttpServer(
+            toolManager = toolManager,
+            port = testPort,
+            serverInfo = Implementation(name = "browser4-e2e-http-test", version = "1.0.0"),
+        )
+        mcpHttpServer.start()
+
+        // Connect the MCP client via Streamable HTTP
+        httpClient = HttpClient(CIO) {
+            install(SSE)
+        }
+        val transport = SseClientTransport(
+            httpClient,
+            "http://localhost:$testPort/mcp/sse",
+        )
+        client = Client(clientInfo = Implementation(name = "test-mcp-client", version = "1.0.0"))
+        client.connect(transport)
+
+        } // runBlocking
+    }
+
+    @AfterEach
+    fun tearDown() {
+        runBlocking {
+            runCatching { client.close() }
+            runCatching { httpClient.close() }
+            runCatching { mcpHttpServer.stop() }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Tool listing
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("listTools returns all registered tools over HTTP SSE")
+    fun listToolsReturnsAllRegisteredTools() = runBlocking {
+        val result = client.listTools()
+        assertNotNull(result)
+        assertEquals(8, result.tools.size,
+            "Expected 8 tools, got: ${result.tools.map { it.name }}")
+    }
+
+    @Test
+    @DisplayName("listTools returns snake_case tool names over HTTP SSE")
+    fun listToolsReturnsCorrectNames() = runBlocking {
+        val names = client.listTools().tools.map { it.name }.toSet()
+        val expected = setOf("navigate", "go_back", "go_forward", "reload", "click", "fill", "get_text", "evaluate")
+        assertTrue(names.containsAll(expected),
+            "Missing tools: ${expected - names}")
+    }
+
+    @Test
+    @DisplayName("each tool has a non-blank description and inputSchema over HTTP")
+    fun eachToolHasDescriptionAndSchema() = runBlocking {
+        val tools = client.listTools().tools
+        tools.forEach { tool ->
+            assertFalse(tool.description.isNullOrBlank(),
+                "Tool '${tool.name}' has a blank description")
+            assertNotNull(tool.inputSchema,
+                "Tool '${tool.name}' has no inputSchema")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Tool execution
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("navigate succeeds over HTTP SSE")
+    fun navigateSucceedsOverHttp() = runBlocking {
+        coEvery { toolManager.execute(any()) } returns toolCallResult(value = "Navigated to https://example.com")
+
+        val result = client.callTool("navigate", mapOf("url" to "https://example.com"))
+        assertFalse(result.isError == true)
+        val text = (result.content.firstOrNull() as? TextContent)?.text
+        assertTrue(text?.contains("https://example.com") == true,
+            "Expected URL in result, got: $text")
+    }
+
+    @Test
+    @DisplayName("click succeeds over HTTP SSE")
+    fun clickSucceedsOverHttp() = runBlocking {
+        coEvery { toolManager.execute(any()) } returns toolCallResult(value = "Clicked #submit-btn")
+
+        val result = client.callTool("click", mapOf("selector" to "#submit-btn"))
+        assertFalse(result.isError == true)
+        val text = (result.content.firstOrNull() as? TextContent)?.text
+        assertTrue(text?.contains("#submit-btn") == true)
+    }
+
+    @Test
+    @DisplayName("get_text returns element text over HTTP SSE")
+    fun getTextReturnsElementTextOverHttp() = runBlocking {
+        coEvery { toolManager.execute(any()) } returns toolCallResult(value = "Welcome")
+
+        val result = client.callTool("get_text", mapOf("selector" to "h1"))
+        assertFalse(result.isError == true)
+        val text = (result.content.firstOrNull() as? TextContent)?.text
+        assertEquals("Welcome", text)
+    }
+
+    @Test
+    @DisplayName("evaluate returns JavaScript result over HTTP SSE")
+    fun evaluateReturnsJsResultOverHttp() = runBlocking {
+        coEvery { toolManager.execute(any()) } returns toolCallResult(value = "42")
+
+        val result = client.callTool("evaluate", mapOf("expression" to "1 + 1"))
+        assertFalse(result.isError == true)
+        val text = (result.content.firstOrNull() as? TextContent)?.text
+        assertEquals("42", text)
+    }
+
+    // -------------------------------------------------------------------------
+    // Error handling
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("AgentToolManager exception propagates as isError=true over HTTP SSE")
+    fun managerExceptionPropagatesAsErrorOverHttp() = runBlocking {
+        coEvery { toolManager.execute(any()) } throws RuntimeException("BrowserProtocol disconnected")
+
+        val result = client.callTool("navigate", mapOf("url" to "https://example.com"))
+        assertTrue(result.isError == true,
+            "Expected isError=true when AgentToolManager throws")
+        val text = (result.content.firstOrNull() as? TextContent)?.text
+        assertTrue(text?.contains("BrowserProtocol disconnected") == true,
+            "Expected error message in result, got: $text")
+    }
+
+    @Test
+    @DisplayName("TcEvaluate with exception propagates as isError=true over HTTP SSE")
+    fun evaluateExceptionPropagatesAsErrorOverHttp() = runBlocking {
+        val evaluate = TcEvaluate(
+            expression = "evaluate(expression=\"bad\")",
+            cause = RuntimeException("SyntaxError"),
+        )
+        coEvery { toolManager.execute(any()) } returns toolCallResult(evaluate = evaluate)
+
+        val result = client.callTool("evaluate", mapOf("expression" to "{{bad"))
+        assertTrue(result.isError == true)
+    }
+
+    // -------------------------------------------------------------------------
+    // Multiple calls / session reuse
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("multiple sequential tool calls succeed over a single HTTP SSE connection")
+    fun multipleSequentialCallsSucceedOverHttp() = runBlocking {
+        coEvery { toolManager.execute(match { it.method == "navigate" }) } returns toolCallResult(value = "navigated")
+        coEvery { toolManager.execute(match { it.method == "getText" }) } returns toolCallResult(value = "headline")
+        coEvery { toolManager.execute(match { it.method == "evaluate" }) } returns toolCallResult(value = "42")
+
+        val nav = client.callTool("navigate", mapOf("url" to "https://example.com"))
+        assertFalse(nav.isError == true, "navigate failed")
+
+        val text = client.callTool("get_text", mapOf("selector" to "h1"))
+        assertFalse(text.isError == true, "get_text failed")
+        assertEquals("headline", (text.content.firstOrNull() as? TextContent)?.text)
+
+        val js = client.callTool("evaluate", mapOf("expression" to "1 + 1"))
+        assertFalse(js.isError == true, "evaluate failed")
+        assertEquals("42", (js.content.firstOrNull() as? TextContent)?.text)
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun toolCallResult(value: Any? = null, evaluate: TcEvaluate? = null): ToolCallResult {
+        val resolvedEvaluate = evaluate ?: TcEvaluate(value = value)
+        return ToolCallResult(
+            evaluate = resolvedEvaluate,
+            message = resolvedEvaluate.exception?.message,
+        )
+    }
+}

--- a/browser4-rest/src/main/kotlin/ai/platon/pulsar/rest/config/McpHttpServerConfiguration.kt
+++ b/browser4-rest/src/main/kotlin/ai/platon/pulsar/rest/config/McpHttpServerConfiguration.kt
@@ -1,0 +1,94 @@
+package ai.platon.pulsar.rest.config
+
+import ai.platon.pulsar.agentic.agents.BasicBrowserAgent
+import ai.platon.pulsar.agentic.context.AgenticContexts
+import ai.platon.pulsar.agentic.mcp.server.McpHttpServer
+import ai.platon.pulsar.common.getLogger
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Lazy
+import org.springframework.context.event.EventListener
+
+/**
+ * Auto-configuration for the MCP-over-HTTP server.
+ *
+ * When `mcp.http.enabled` is `true` (the default), this configuration
+ * starts an embedded Ktor HTTP server that exposes Browser4's browser
+ * automation tools via the standard MCP Streamable HTTP (SSE) protocol.
+ *
+ * ## How it works
+ *
+ * 1. On [ApplicationReadyEvent], a dedicated [BasicBrowserAgent] session
+ *    is acquired (reusing an existing one if available, or creating one).
+ * 2. The agent's [AgentToolManager] is wrapped in a [McpHttpServer].
+ * 3. The server starts on the configured port (default 8088) and accepts
+ *    MCP client connections at `/mcp/sse`.
+ *
+ * ## Configuration
+ *
+ * ```
+ * # application.properties
+ * mcp.http.enabled=true        # enable/disable (default: true)
+ * mcp.http.port=8088           # listen port (default: 8088)
+ * mcp.http.host=0.0.0.0        # bind host (default: 0.0.0.0)
+ * mcp.http.headless=false      # run Chrome in headless mode (default: false)
+ * ```
+ *
+ * ## Clients
+ *
+ * Any MCP-compatible client can connect:
+ * - Claude Desktop: configure `mcpServers` with a `url` pointing to
+ *   `http://host:8088/mcp/sse` (streamable-http transport)
+ * - Cursor / Windsurf: same URL in their MCP server configuration
+ * - Custom clients: use the MCP SDK's `StreamableHttpClientTransport`
+ */
+@Configuration
+@ConditionalOnProperty(name = ["mcp.http.enabled"], havingValue = "true", matchIfMissing = true)
+class McpHttpServerConfiguration {
+
+    private val logger = getLogger(this)
+
+    /**
+     * The MCP HTTP server instance.
+     *
+     * Marked [Lazy(false)] so it is instantiated eagerly even when
+     * `spring.main.lazy-initialization=true`.
+     */
+    @Bean(destroyMethod = "stop")
+    @Lazy(false)
+    fun mcpHttpServer(): McpHttpServer {
+        val port = System.getProperty("mcp.http.port")?.toIntOrNull() ?: McpHttpServer.DEFAULT_MCP_HTTP_PORT
+        val host = System.getProperty("mcp.http.host", "0.0.0.0")
+        val headless = System.getProperty("mcp.http.headless", "false").toBoolean()
+
+        logger.info("Creating MCP HTTP server session (headless={})", headless)
+
+        val session = AgenticContexts.getOrCreateSession(headless = headless)
+        val agent = session.companionAgent as? BasicBrowserAgent
+            ?: throw IllegalStateException(
+                "MCP HTTP server requires a BasicBrowserAgent, but companion agent is ${session.companionAgent::class.simpleName}"
+            )
+
+        return McpHttpServer(
+            toolManager = agent.agentToolManager,
+            port = port,
+            host = host,
+        )
+    }
+
+    /**
+     * Start the MCP HTTP server once the application is fully initialized.
+     *
+     * We use [ApplicationReadyEvent] rather than [jakarta.annotation.PostConstruct]
+     * because the agent session may reference Spring-managed beans that aren't
+     * fully available during post-construction.
+     */
+    @EventListener(ApplicationReadyEvent::class)
+    fun onApplicationReady(mcpHttpServer: McpHttpServer) {
+        // Start after Spring Boot's own server has bound, avoiding port
+        // conflicts and ensuring all session infrastructure is ready.
+        mcpHttpServer.start()
+    }
+}


### PR DESCRIPTION
## Summary

Adds a standards-compliant MCP HTTP transport alongside the existing STDIO transport, allowing remote MCP clients (Claude Desktop, Cursor, Windsurf) to connect to Browser4 over HTTP.

## Changes

### New files
- **`McpHttpServer.kt`** — Embedded Ktor CIO server exposing MCP SSE endpoints:
  - `GET  /mcp/sse` — SSE stream for server→client messages
  - `POST /mcp/message?sessionId=...` — client→server JSON-RPC
  - Uses the official `io.modelcontextprotocol.kotlin.sdk` `SseServerTransport`
  - Shares a single `Browser4MCPServer` across all client sessions

- **`McpHttpServerConfiguration.kt`** — Spring Boot auto-configuration:
  - Conditional on `mcp.http.enabled=true` (default: true)
  - Creates a dedicated session with `BasicBrowserAgent` on `ApplicationReadyEvent`
  - Configurable via system properties: `mcp.http.port`, `mcp.http.host`, `mcp.http.headless`

- **`McpHttpServerE2ETest.kt`** — 10 E2E tests (all passing):
  - Full MCP protocol stack: HTTP → SSE → JSON-RPC → `Browser4MCPServer` → `AgentToolManager`
  - Tests tool listing, tool execution, error propagation, and multi-call session reuse
  - Uses mocked `AgentToolManager` (no real browser needed)

### Updated files
- **`Browser4MCPServerRunner.kt`** — Added `--transport http`, `--headless`, `--port`, `--help` options
- **`browser4-agentic/pom.xml`** — Added `ktor-server-cio-jvm` and `ktor-client-cio-jvm` (test scope)

## Usage

```bash
# Standalone HTTP server
java -jar Browser4.jar --app mcp --transport http --port 8088

# Spring Boot (auto-starts alongside REST API)
java -jar Browser4.jar    # MCP HTTP on port 8088
```

Claude Desktop config:
```json
{
  "mcpServers": {
    "browser4": {
      "command": "java",
      "args": ["-jar", "/path/to/Browser4.jar", "--app", "mcp", "--transport", "http"]
    }
  }
}
```

## Architecture

```
MCP Client ──HTTP──▶ Ktor CIO :8088 ──SSE──▶ Browser4MCPServer ──▶ AgentToolManager ──▶ Chrome
                      GET  /mcp/sse  (SSE stream)
                      POST /mcp/message?sessionId=... (JSON-RPC)
```

The STDIO MCP server (existing) and the new HTTP MCP server share the same `Browser4MCPServer` and `AgentToolManager` — they differ only in transport.

## Out of scope

- Plugin/custom tools (crawl, swarm, webdb, html_snapshot) remain REST-only — they require Spring-wired executors not available in the MCP server
- CLI still uses the custom REST protocol (`MCPToolController`) — separate discussion
- `StreamableHttpClientTransport` (newer MCP spec) — server side uses the compatible `SseServerTransport`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP/SSE transport support for Browser4 MCP tools.
  * Added configurable transport, port, host, headless, and help options.
  * Added session-aware communication for multiple MCP connections.
  * Added Spring Boot auto-configuration with automatic server startup and shutdown.
  * Added CLI usage documentation and validation for invalid options.

* **Bug Fixes**
  * Improved handling of missing or unknown session identifiers and server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->