### PR TITLE
ci(tests): run Maven tests under a virtual display (Xvfb)

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -84,6 +84,26 @@ runs:
         MAVEN_CMD=$([ -f "./mvnw" ] && echo "./mvnw" || echo "mvn")
         echo "MAVEN_CMD=$MAVEN_CMD" >> $GITHUB_ENV
 
+        # Provide a virtual display on headless CI runners. Pulsar's
+        # BrowserSettings.withGUI degrades to HEADLESS by design when the host
+        # has no GUI support, so GUI display-mode tests need a real X display.
+        if [ -z "${DISPLAY:-}" ]; then
+          if command -v Xvfb &> /dev/null; then
+            Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp > /tmp/xvfb.log 2>&1 &
+            echo "DISPLAY=:99" >> $GITHUB_ENV
+            # Wait for the X socket so later steps can connect right away
+            for _ in $(seq 1 20); do
+              [ -S /tmp/.X11-unix/X99 ] && break
+              sleep 0.25
+            done
+            echo "✅ Started Xvfb on :99"
+          else
+            echo "⚠️ Xvfb not installed; GUI display-mode tests will fall back to headless"
+          fi
+        else
+          echo "✅ DISPLAY already set: $DISPLAY"
+        fi
+
         # Create test results directory
         mkdir -p test-results
 


### PR DESCRIPTION
## What

Make the shared \un-tests\ action provide a virtual display (Xvfb) when \DISPLAY\ is unset, so Maven tests run with real GUI display-mode semantics on headless CI runners.

## Why

Pulsar's \BrowserSettings.withGUI\ deliberately degrades to HEADLESS when the host has no GUI support (\Runtimes.hasOnlyHeadlessBrowser\): no DISPLAY, no Xorg, no desktop session. The display-mode capability tests (environment-aware since \c023c13b\) pass either way, but without a display CI only ever exercises the fallback path — GUI display-mode behavior is never actually guarded.

With Xvfb on \:99\, \supportHeadedBrowser()\ resolves true in CI and the tests assert \GUI\ for real, matching the \open --headed\ semantics fixed in the display-mode work.

## Change

\\\ash
# in Pre-test Setup, when DISPLAY is unset and Xvfb is available:
Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp &
echo "DISPLAY=:99" >> \
\\\

- 20 lines, no new dependencies (xvfb is preinstalled on GitHub-hosted ubuntu-24.04 runners)
- Graceful fallback: if Xvfb is missing, tests run exactly as before
- Affects all callers of \un-tests\: ci.yml, pr.yml, nightly.yml

## Verification

Tag \4.13.6-ci.3\ (this commit):
- CI/CD Pipeline: success (run 32121022540) — \✅ Started Xvfb on :99\, 1841 tests, 0 failures, \AbstractPulsarSessionTest\ 9/9
- Cross-Platform Smoke Test: success

## Follow-up

Watch one nightly run after merge — nightly's Slow/Integration suite is the first full run under the virtual display.