### PR TITLE
fix(swarm): guarantee task termination and bounded retries (#577)

### DIFF
--- a/browser4-agent-tools/src/main/kotlin/ai/platon/pulsar/agentic/tools/advanced/crawl/common/XSQLScrapeHyperlink.kt
+++ b/browser4-agent-tools/src/main/kotlin/ai/platon/pulsar/agentic/tools/advanced/crawl/common/XSQLScrapeHyperlink.kt
@@ -36,10 +36,38 @@ open class XSQLHyperlink(
                 it
             }
             onLoaded.addLast { url, page ->
-                if (!hyperlink.isDone) {
-                    hyperlink.complete(page ?: GoraWebPage.NIL)
+                val p = page ?: GoraWebPage.NIL
+                when {
+                    hyperlink.isDone -> {
+                        // Already completed (defensive: a duplicate loaded event).
+                        response.refresh(isDone = true)
+                    }
+
+                    // Transient failure or cancellation: the task has been
+                    // re-queued for another attempt. Keep it in a non-terminal
+                    // state so the CLI keeps polling and a later attempt can
+                    // complete the task. This also prevents the task from being
+                    // reported "done" with an empty result mid-retry.
+                    // NOTE: checked before isFailed — both the canceled and the
+                    // retry protocol statuses also report isFailed.
+                    p.isCanceled || p.protocolStatus.isRetry -> {
+                        response.emitEvent("retry")
+                        response.message = "Page fetch is being retried: ${p.protocolStatus.reason ?: "transient failure"}"
+                        response.refresh(ResourceStatus.SC_ACCEPTED, p.protocolStatus.minorCode, false)
+                    }
+
+                    // Terminal failure: the fetch failed. This includes a
+                    // canceled task whose retry budget was exhausted — the
+                    // runner clears the canceled flag and marks its status as
+                    // failed. Completing here with an empty result set would
+                    // report a "successful" task whose page was never fetched —
+                    // instead mark it as failed with the real reason.
+                    p.protocolStatus.isFailed || p.isNil || !p.isFetched -> {
+                        hyperlink.fail(p, page == null)
+                    }
+
+                    else -> hyperlink.complete(p)
                 }
-                response.refresh(isDone = true)
             }
         }
     }
@@ -99,6 +127,34 @@ open class XSQLHyperlink(
         } catch (t: Throwable) {
             warnInterruptible(this, t, "Error extracting data from page: ${page.url}")
         }
+    }
+
+    /**
+     * Mark the task as failed with a clear diagnostic instead of completing it
+     * with an empty result. Used when the page was never fetched, was dropped,
+     * or the fetch failed/canceled — so a completed task either contains data
+     * or reports the real failure reason.
+     * */
+    open fun fail(page: WebPage, pageWasNull: Boolean = false) {
+        val status = page.protocolStatus
+        val reason = status.reason?.toString()?.takeIf { it.isNotBlank() } ?: "unknown"
+        response.pageContentBytes = page.contentLength.toInt().coerceAtLeast(0)
+        response.pageStatusCode = status.minorCode
+        response.statusCode = ResourceStatus.SC_EXPECTATION_FAILED
+        response.message = when {
+            page.isNil || pageWasNull || !page.isFetched ->
+                "The page was never fetched. The task may have been dropped or evicted. Re-run the query with -refresh to retry."
+
+            page.isCanceled ->
+                "The page fetch was canceled ($reason). Re-fetch with -refresh or -ignoreFailure to retry."
+
+            status.isFailed ->
+                "Page fetch failed with status ${status.minorCode} ($reason). Re-fetch with -refresh or -ignoreFailure to retry."
+
+            else ->
+                "The page was not fetched (protocol status ${status.minorCode}: $reason)."
+        }
+        complete(page)
     }
 
     protected open fun doExtract(page: WebPage, document: FeaturedDocument) {

--- a/browser4-agent-tools/src/test/kotlin/ai/platon/pulsar/agentic/tools/advanced/crawl/common/XSQLScrapeHyperlinkTest.kt
+++ b/browser4-agent-tools/src/test/kotlin/ai/platon/pulsar/agentic/tools/advanced/crawl/common/XSQLScrapeHyperlinkTest.kt
@@ -1,0 +1,198 @@
+package ai.platon.pulsar.agentic.tools.advanced.crawl.common
+
+import ai.platon.pulsar.agentic.tools.advanced.crawl.ScrapeRequest
+import ai.platon.pulsar.agentic.tools.advanced.crawl.refresh
+import ai.platon.pulsar.common.ResourceStatus
+import ai.platon.pulsar.common.config.MutableConfig
+import ai.platon.pulsar.persist.ProtocolStatus
+import ai.platon.pulsar.persist.RetryScope
+import ai.platon.pulsar.persist.WebPage
+import ai.platon.pulsar.persist.metadata.ProtocolStatusCodes
+import ai.platon.pulsar.persist.model.GoraWebPage
+import ai.platon.pulsar.skeleton.session.PulsarSession
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Proxy
+
+/**
+ * Regression tests for issue #577: completed swarm tasks must either contain
+ * fetched data or report the real failure reason. Previously the onLoaded
+ * handler completed the hyperlink with whatever page it received — including
+ * nil/unfetched pages — so a dropped task was reported "done" with an empty
+ * result set and pageContentBytes = 0.
+ */
+class XSQLScrapeHyperlinkTest {
+
+    private val conf = MutableConfig(true).toVolatileConfig()
+
+    private fun hyperlink(): XSQLHyperlink {
+        return XSQLHyperlink(
+            ScrapeRequest("select dom_text(dom) as t from load_and_select('@url', ':root')"),
+            NormXSQL("https://example.com", "", "select dom_text(dom) as t"),
+            fakeSession(),
+        )
+    }
+
+    /**
+     * The hyperlink never touches the session for the onLoaded paths under
+     * test, so a no-op dynamic proxy is enough.
+     */
+    private fun fakeSession(): PulsarSession {
+        val handler = java.lang.reflect.InvocationHandler { _, method, _ ->
+            when (method.returnType) {
+                java.lang.Boolean.TYPE -> false
+                java.lang.Integer.TYPE -> 0
+                java.lang.Long.TYPE -> 0L
+                java.lang.Void.TYPE -> null
+                else -> null
+            }
+        }
+        return Proxy.newProxyInstance(
+            PulsarSession::class.java.classLoader,
+            arrayOf(PulsarSession::class.java),
+            handler,
+        ) as PulsarSession
+    }
+
+    private fun fireLoaded(hyperlink: XSQLHyperlink, page: WebPage?) {
+        hyperlink.eventHandlers.crawlEventHandlers.onLoaded.invoke(hyperlink, page)
+    }
+
+    private fun newPage(url: String = "https://example.com"): GoraWebPage {
+        return GoraWebPage.newWebPage(url, conf)
+    }
+
+    @Test
+    fun `nil page marks the task as failed with a clear reason`() {
+        val link = hyperlink()
+
+        fireLoaded(link, GoraWebPage.NIL)
+
+        val response = link.response
+        assertTrue(response.isDone, "A nil page must produce a terminal state")
+        assertEquals(ResourceStatus.SC_EXPECTATION_FAILED, response.statusCode)
+        assertEquals(0, response.pageContentBytes)
+        assertNotNull(response.message)
+        assertTrue(
+            response.message!!.contains("never fetched"),
+            "Message must explain that the page was never fetched: ${response.message}"
+        )
+    }
+
+    @Test
+    fun `null page marks the task as failed with a clear reason`() {
+        val link = hyperlink()
+
+        fireLoaded(link, null)
+
+        val response = link.response
+        assertTrue(response.isDone, "A null page must produce a terminal state")
+        assertEquals(ResourceStatus.SC_EXPECTATION_FAILED, response.statusCode)
+        assertNotNull(response.message)
+        assertTrue(response.message!!.contains("never fetched"), "Message: ${response.message}")
+    }
+
+    @Test
+    fun `failed page marks the task as failed with the page status`() {
+        val link = hyperlink()
+        val page = newPage()
+        page.protocolStatus = ProtocolStatus.failed(ProtocolStatusCodes.SC_NOT_FOUND)
+        page.isFetched = true
+
+        fireLoaded(link, page)
+
+        val response = link.response
+        assertTrue(response.isDone, "A failed page must produce a terminal state")
+        assertEquals(ResourceStatus.SC_EXPECTATION_FAILED, response.statusCode)
+        assertEquals(ProtocolStatusCodes.SC_NOT_FOUND, response.pageStatusCode)
+        assertNotNull(response.message)
+        assertTrue(response.message!!.contains("failed"), "Message: ${response.message}")
+    }
+
+    @Test
+    fun `retry page keeps the task in a non-terminal state`() {
+        val link = hyperlink()
+        val page = newPage()
+        page.protocolStatus = ProtocolStatus.retry(RetryScope.CRAWL, "privacy context exhausted")
+        page.isFetched = true
+
+        fireLoaded(link, page)
+
+        val response = link.response
+        assertFalse(response.isDone, "A retrying task must not be reported as done")
+        assertEquals("retry", response.event)
+        assertNotNull(response.message)
+        assertTrue(response.message!!.contains("retried"), "Message: ${response.message}")
+    }
+
+    @Test
+    fun `canceled page keeps the task in a non-terminal state`() {
+        val link = hyperlink()
+        val page = newPage()
+        page.protocolStatus = ProtocolStatus.cancel("privacy context recycled")
+        page.isCanceled = true
+
+        fireLoaded(link, page)
+
+        val response = link.response
+        assertFalse(response.isDone, "A canceled task that is re-queued must not be reported as done")
+        assertEquals("retry", response.event)
+    }
+
+    @Test
+    fun `retry attempt after transient failure can still complete the task`() {
+        val link = hyperlink()
+        val page = newPage()
+        page.protocolStatus = ProtocolStatus.retry(RetryScope.CRAWL, "privacy context exhausted")
+        page.isFetched = true
+
+        fireLoaded(link, page)
+        assertFalse(link.response.isDone, "Transient failure must not complete the task")
+
+        // Later attempt succeeds — the task completes.
+        val successPage = newPage()
+        successPage.protocolStatus = ProtocolStatus.STATUS_SUCCESS
+        successPage.isFetched = true
+        successPage.setByteArrayContent("<html><body><h3>title</h3></body></html>".toByteArray())
+        link.response.refresh(ResourceStatus.SC_OK, ProtocolStatusCodes.SC_OK, false)
+
+        fireLoaded(link, successPage)
+
+        assertTrue(link.response.isDone, "A later success must complete the task")
+    }
+
+    @Test
+    fun `success page completes the task`() {
+        val link = hyperlink()
+        val page = newPage()
+        page.protocolStatus = ProtocolStatus.STATUS_SUCCESS
+        page.isFetched = true
+        page.setByteArrayContent("<html><body>hello</body></html>".toByteArray())
+
+        fireLoaded(link, page)
+
+        assertTrue(link.response.isDone, "A successful fetch must complete the task")
+        assertEquals(link.uuid, link.response.id)
+    }
+
+    @Test
+    fun `failed status after a retry attempt marks the task as failed`() {
+        val link = hyperlink()
+        val retryPage = newPage()
+        retryPage.protocolStatus = ProtocolStatus.retry(RetryScope.CRAWL, "privacy context exhausted")
+        retryPage.isFetched = true
+
+        fireLoaded(link, retryPage)
+        assertFalse(link.response.isDone)
+
+        // The retry budget is exhausted — the runner marks the page as failed.
+        val exhaustedPage = newPage()
+        exhaustedPage.protocolStatus = ProtocolStatus.failed(ProtocolStatusCodes.SC_REQUEST_TIMEOUT)
+        exhaustedPage.isFetched = true
+
+        fireLoaded(link, exhaustedPage)
+
+        assertTrue(link.response.isDone, "A failed final attempt must produce a terminal state")
+        assertEquals(ResourceStatus.SC_EXPECTATION_FAILED, link.response.statusCode)
+    }
+}

--- a/browser4-agentic/src/main/kotlin/ai/platon/pulsar/agentic/context/AgenticContexts.kt
+++ b/browser4-agentic/src/main/kotlin/ai/platon/pulsar/agentic/context/AgenticContexts.kt
@@ -11,6 +11,7 @@ import ai.platon.pulsar.api.model.DisplayMode
 import ai.platon.pulsar.common.Systems
 import ai.platon.pulsar.common.browser.BrowserProfileMode
 import ai.platon.pulsar.common.config.CapabilityTypes
+import ai.platon.pulsar.common.getLogger
 import ai.platon.pulsar.skeleton.PulsarSettings
 import ai.platon.pulsar.skeleton.context.PulsarContexts
 import org.springframework.context.ApplicationContext
@@ -38,6 +39,8 @@ import org.springframework.context.support.StaticApplicationContext
  */
 @Suppress("unused")
 object AgenticContexts {
+    private val logger = getLogger(AgenticContexts::class)
+
     init {
         Systems.setPropertyIfAbsent(CapabilityTypes.APP_NAME_KEY, "browser4")
     }
@@ -178,6 +181,17 @@ object AgenticContexts {
     @Throws(Exception::class)
     fun ensureSwarmSession(settings: PulsarSettings, applicationContext: ApplicationContext): AgenticSession {
         val context = getOrCreate(applicationContext) as AbstractAgenticContext
+        val zombies = context.sessions.values.filterIsInstance<AgenticSession>()
+            .filter { it.label == SWARM_SESSION_LABEL && !it.isActive }
+
+        // A closed swarm session must never be returned or kept in the registry:
+        // new tasks submitted to a closed session are never consumed and appear
+        // "queued" forever. Drop any zombie sessions before lookup/creation.
+        zombies.forEach { zombie ->
+            logger.info("Removing inactive SWARM session #{} from the context registry", zombie.id)
+            context.closeSession(zombie)
+        }
+
         val swarmSession =
             context.sessions.values.filterIsInstance<AgenticSession>().firstOrNull { it.label == SWARM_SESSION_LABEL }
         if (swarmSession != null) {

--- a/browser4-core/browser4-skeleton/src/main/kotlin/ai/platon/pulsar/loop/impl/StreamingTaskLoop.kt
+++ b/browser4-core/browser4-skeleton/src/main/kotlin/ai/platon/pulsar/loop/impl/StreamingTaskLoop.kt
@@ -125,18 +125,45 @@ open class StreamingTaskLoop(
         if (swarmSession == null) {
             logger.warn("SWARM session does not exist, falling back to default")
         }
-        val session = swarmSession ?: cx.getOrCreateSession()
-
-        // clear the global illegal states, so the newly created crawler can work properly
-        StreamingTaskRunner.clearIllegalState()
 
         val urls = urlFeeder.asSequence()
-        _taskRunner = StreamingTaskRunner(urls, session, autoClose = false)
+        var currentSession = swarmSession ?: cx.getOrCreateSession()
+        _taskRunner = StreamingTaskRunner(urls, currentSession, autoClose = false)
 
         crawlJob = scope.launch {
             supervisorScope {
                 started.countDown()
-                _taskRunner.run(this)
+
+                // Keep a working crawler for as long as the loop is started:
+                // if the task runner exits unexpectedly (e.g. an exception
+                // escaped the main loop or a global illegal state was set),
+                // restart it. Without this, the loop stays marked as "running"
+                // while nothing consumes the url pool, and every newly
+                // submitted task stays queued forever.
+                while (running.get() && cx.isActive) {
+                    // The swarm session may have been closed and recreated;
+                    // re-resolve it so a fresh runner is bound to the live one.
+                    currentSession = cx.sessions.values.firstOrNull { it.label == "SWARM" } ?: currentSession
+
+                    // clear the global illegal states, so the newly created crawler can work properly
+                    StreamingTaskRunner.clearIllegalState()
+
+                    // A fresh runner per attempt: a used runner keeps its
+                    // BREAK flow state and would exit again immediately.
+                    val taskRunner = StreamingTaskRunner(urls, currentSession, autoClose = false)
+                    _taskRunner = taskRunner
+
+                    val job = launch { taskRunner.run(this) }
+                    job.join()
+
+                    if (running.get() && cx.isActive) {
+                        logger.warn(
+                            "Task runner #{} exited unexpectedly, restarting in {}s | {}",
+                            taskRunner.id, 2, taskRunner
+                        )
+                        delay(2000)
+                    }
+                }
             }
         }
     }

--- a/browser4-core/browser4-skeleton/src/main/kotlin/ai/platon/pulsar/loop/impl/StreamingTaskRunner.kt
+++ b/browser4-core/browser4-skeleton/src/main/kotlin/ai/platon/pulsar/loop/impl/StreamingTaskRunner.kt
@@ -16,7 +16,9 @@ import ai.platon.pulsar.common.urls.URLUtils
 import ai.platon.pulsar.common.urls.UrlAware
 import ai.platon.pulsar.core.api.WebPage
 import ai.platon.pulsar.persist.AbstractWebPage
+import ai.platon.pulsar.persist.ProtocolStatus
 import ai.platon.pulsar.persist.WebDBException
+import ai.platon.pulsar.persist.metadata.ProtocolStatusCodes
 import ai.platon.pulsar.skeleton.common.AppSystemInfo
 import ai.platon.pulsar.skeleton.common.message.PageLoadStatusFormatter
 import ai.platon.pulsar.skeleton.common.metrics.MetricsSystem
@@ -24,6 +26,7 @@ import ai.platon.pulsar.skeleton.common.options.LoadOptions
 import ai.platon.pulsar.skeleton.context.PulsarContexts
 import ai.platon.pulsar.skeleton.context.support.AbstractPulsarContext
 import ai.platon.pulsar.skeleton.session.PulsarSession
+import ai.platon.pulsar.skeleton.workflow.common.url.CompletableHyperlink
 import ai.platon.pulsar.skeleton.workflow.common.url.ListenableUrl
 import com.codahale.metrics.Gauge
 import kotlinx.coroutines.*
@@ -36,6 +39,7 @@ import java.nio.file.StandardOpenOption
 import java.nio.file.attribute.PosixFilePermissions
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentSkipListSet
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -116,6 +120,12 @@ open class StreamingTaskRunner(
     autoClose: Boolean = true,
 ) : AbstractTaskRunner(session, autoClose) {
     companion object {
+        /**
+         * Fallback retry budget when neither the page nor the link declares one.
+         * Matches the default of `-nMaxRetry` in LoadOptions.
+         * */
+        private const val DEFAULT_MAX_RETRIES = 3
+
         private var globalState = GlobalCrawlState()
 
         init {
@@ -165,6 +175,14 @@ open class StreamingTaskRunner(
     private val isProxyEnabled get() = ProxyPoolManager.isProxyEnabled(sessionConfig)
     private val proxyPool: ProxyPool? get() = if (isProxyEnabled) context.getBeanOrNull(ProxyPool::class) else null
     private var proxyOutOfService = 0
+
+    /**
+     * Retry budgets for tasks whose load attempts produced no page at all
+     * (timeout or exception), keyed by the url to fetch. Page objects carry
+     * their own [WebPage.fetchRetries] counter, so this map is only for the
+     * null-page case.
+     * */
+    private val nullPageRetryCounts = ConcurrentHashMap<UrlAware, Int>()
 
     /**
      * Override the main loop concurrency.
@@ -597,6 +615,12 @@ open class StreamingTaskRunner(
 
         if (page != null) {
             collectStatAfterLoad(page)
+
+            // Reset the null-page retry budget once the task reaches a state
+            // that is neither retrying nor canceled.
+            if (!page.isCanceled && !page.protocolStatus.isRetry) {
+                nullPageRetryCounts.remove(url)
+            }
         }
 
         emit(CrawlEvents.loaded, url, page)
@@ -822,6 +846,27 @@ open class StreamingTaskRunner(
 
     private suspend fun handleCanceled(url: UrlAware, page: WebPage?) {
         globalState.globalMetrics.cancels.mark()
+
+        if (page != null) {
+            page.fetchRetries++
+            if (page.fetchRetries > maxRetriesOf(url, page)) {
+                // A task that is canceled over and over (e.g. privacy contexts
+                // recycling) must eventually stop being re-queued, otherwise it
+                // loops forever and never reaches a terminal state. Mark the
+                // page as failed (and clear the canceled flag) so downstream
+                // consumers (e.g. a scrape hyperlink) can report the task as
+                // failed instead of leaving it in an endless "canceled" state.
+                globalState.globalMetrics.gone.mark()
+                page.isCanceled = false
+                page.protocolStatus = ProtocolStatus.failed(ProtocolStatusCodes.SC_REQUEST_TIMEOUT)
+                if (taskLogger.isInfoEnabled) {
+                    val message = PageLoadStatusFormatter(page, prefix = "Gone")
+                    taskLogger.info("{}, cancel budget exhausted, no more retries", message)
+                }
+                return
+            }
+        }
+
         val delay = page?.retryDelay?.takeIf { !it.isZero } ?: Duration.ofSeconds(10)
         // Delay fetching the page.
         fetchDelayed(url, delay)
@@ -845,30 +890,90 @@ open class StreamingTaskRunner(
     }
 
     private fun handleRetry0(url: UrlAware, page: WebPage?) {
-        val nextRetryNumber = 1 + (page?.fetchRetries ?: 0)
-        if (page != null && nextRetryNumber > page.maxRetries) {
-            // should not go here, because the page should be marked as GONE
+        if (page == null) {
+            handleNullPageRetry(url)
+            return
+        }
+
+        val nextRetryNumber = 1 + page.fetchRetries
+        if (nextRetryNumber > maxRetriesOf(url, page)) {
+            // The retry budget is exhausted: stop re-queueing the task and mark
+            // the page as failed so downstream consumers (e.g. a scrape
+            // hyperlink) reach a terminal state and can report the real failure
+            // reason instead of the task retrying forever. Previously
+            // page.fetchRetries was never advanced in the streaming loop, so
+            // this guard never tripped and tasks like PrivacyException-driven
+            // crawl retries ran unbounded.
             globalState.globalMetrics.gone.mark()
+            page.protocolStatus = ProtocolStatus.failed(ProtocolStatusCodes.SC_REQUEST_TIMEOUT)
             if (taskLogger.isInfoEnabled) {
-                val message = PageLoadStatusFormatter(page, prefix = "Gone (unexpected)")
-                taskLogger.info("{}, gone unexpected, no retry", message)
+                val message = PageLoadStatusFormatter(page, prefix = "Gone")
+                taskLogger.info("{}, retry budget exhausted ({}), no more retries", message, nextRetryNumber)
             }
             return
         }
 
-        val delay = page?.retryDelay?.takeIf { !it.isZero } ?: retryDelayPolicy(nextRetryNumber, url)
-//        val delayCache = globalState.globalCache.urlPool.delayCache
-//        // erase -refresh options
-//        url.args = url.args?.replace("-refresh", "-refresh-erased")
-//        delayCache.add(DelayUrl(url, delay))
+        // Advance the retry counter so the next attempt's number grows and the
+        // budget above is eventually exhausted. The streaming loop never
+        // incremented this counter (the WebDB fetch schedule that does it in
+        // batch mode is not used here), which caused unbounded retries.
+        page.fetchRetries++
+
+        val delay = page.retryDelay?.takeIf { !it.isZero } ?: retryDelayPolicy(nextRetryNumber, url)
         fetchDelayed(url, delay)
 
         globalState.globalMetrics.retries.mark()
-        if (page != null && taskLogger.isInfoEnabled) {
+        if (taskLogger.isInfoEnabled) {
             val symbol = PopularEmoji.FENCER
             val prefix = "$symbol Trying ${nextRetryNumber}th ${delay.readable()} later | "
             taskLogger.info("{}, retrying", PageLoadStatusFormatter(page, prefix = prefix))
         }
+    }
+
+    /**
+     * Handle a retry for an attempt that produced no page at all (timeout or
+     * exception in [loadWithTimeout]). There is no page object to carry
+     * [WebPage.fetchRetries], so the retry budget is tracked on the runner.
+     * */
+    private fun handleNullPageRetry(url: UrlAware) {
+        val attempts = nullPageRetryCounts.merge(url, 1, Int::plus) ?: 1
+        val maxRetries = maxRetriesOf(url, null)
+        if (attempts > maxRetries) {
+            globalState.globalMetrics.gone.mark()
+            if (taskLogger.isInfoEnabled) {
+                taskLogger.info("Null page for {}: retry budget exhausted ({}), no more retries", url, attempts)
+            }
+            return
+        }
+
+        fetchDelayed(url, retryDelayPolicy(attempts, url))
+        globalState.globalMetrics.retries.mark()
+        if (taskLogger.isInfoEnabled) {
+            val symbol = PopularEmoji.FENCER
+            taskLogger.info("{} Null page for {}, retrying ({}/{})", symbol, url, attempts, maxRetries)
+        }
+    }
+
+    /**
+     * The maximum number of retries for a task. Uses the page's budget when
+     * available, otherwise the link's `nMaxRetry`, otherwise a sane default.
+     * The page's [WebPage.maxRetries] may be 0 (e.g. pages created without
+     * [ai.platon.pulsar.skeleton.common.options.LoadOptions]), which would make
+     * `nextRetryNumber > maxRetries` true on the very first retry — too
+     * aggressive, so a 0 value is treated as unset.
+     * */
+    private fun maxRetriesOf(url: UrlAware, page: WebPage?): Int {
+        val pageMaxRetries = page?.maxRetries ?: 0
+        if (pageMaxRetries > 0) {
+            return pageMaxRetries
+        }
+
+        val linkMaxRetries = (url as? CompletableHyperlink<*>)?.nMaxRetry ?: 0
+        if (linkMaxRetries > 0) {
+            return linkMaxRetries
+        }
+
+        return DEFAULT_MAX_RETRIES
     }
 
     private fun fetchDelayed(url: UrlAware, delay: Duration) {

--- a/browser4-core/browser4-skeleton/src/test/kotlin/ai/platon/pulsar/loop/impl/StreamingTaskRunnerRetryTest.kt
+++ b/browser4-core/browser4-skeleton/src/test/kotlin/ai/platon/pulsar/loop/impl/StreamingTaskRunnerRetryTest.kt
@@ -1,0 +1,104 @@
+package ai.platon.pulsar.loop.impl
+
+import ai.platon.pulsar.common.config.ImmutableConfig
+import ai.platon.pulsar.common.urls.PlainUrl
+import ai.platon.pulsar.common.urls.UrlAware
+import ai.platon.pulsar.core.api.WebPage
+import ai.platon.pulsar.persist.ProtocolStatus
+import ai.platon.pulsar.persist.RetryScope
+import ai.platon.pulsar.persist.metadata.ProtocolStatusCodes
+import ai.platon.pulsar.persist.model.GoraWebPage
+import ai.platon.pulsar.skeleton.context.support.AbstractPulsarContext
+import ai.platon.pulsar.skeleton.session.BasicPulsarSession
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for issue #577: the streaming task loop retried tasks
+ * without any bound because `page.fetchRetries` was never advanced in the
+ * streaming path (the WebDB fetch schedule that increments it is not used by
+ * [StreamingTaskRunner]). A PrivacyException-driven crawl retry therefore ran
+ * forever ("Trying 1th 43s later" in the logs).
+ */
+class StreamingTaskRunnerRetryTest {
+
+    private val context = mockk<AbstractPulsarContext>(relaxed = true)
+    private val session = BasicPulsarSession(context, ImmutableConfig().toVolatileConfig())
+    private val runner = StreamingTaskRunner(emptySequence<UrlAware>(), session, autoClose = false)
+
+    private fun invokeHandleRetry0(url: UrlAware, page: WebPage?) {
+        val method = StreamingTaskRunner::class.java
+            .getDeclaredMethod("handleRetry0", UrlAware::class.java, WebPage::class.java)
+        method.isAccessible = true
+        method.invoke(runner, url, page)
+    }
+
+    private fun retryPage(url: String = "https://example.com"): GoraWebPage {
+        val page = GoraWebPage.newWebPage(url, ImmutableConfig().toVolatileConfig())
+        page.protocolStatus = ProtocolStatus.retry(RetryScope.CRAWL, "PrivacyException")
+        return page
+    }
+
+    @Test
+    fun `retry within budget advances the retry counter`() {
+        val page = retryPage()
+        page.fetchRetries = 0
+        page.maxRetries = 3
+
+        invokeHandleRetry0(PlainUrl("https://example.com"), page)
+
+        assertEquals(1, page.fetchRetries, "The streaming loop must advance the retry counter")
+        assertTrue(page.protocolStatus.isRetry)
+    }
+
+    @Test
+    fun `retry budget exhaustion stops the retry loop and marks the page as failed`() {
+        val page = retryPage()
+        page.fetchRetries = 3
+        page.maxRetries = 3
+
+        invokeHandleRetry0(PlainUrl("https://example.com"), page)
+
+        // No more retries: the page must reach a terminal (failed) state so
+        // downstream consumers can report the failure instead of retrying forever.
+        assertTrue(
+            page.protocolStatus.isFailed,
+            "Expected a failed protocol status but got ${page.protocolStatus}"
+        )
+        assertEquals(ProtocolStatusCodes.SC_REQUEST_TIMEOUT, page.protocolStatus.minorCode)
+    }
+
+    @Test
+    fun `maxRetries fallback protects pages without an explicit budget`() {
+        val page = retryPage()
+        page.fetchRetries = 3
+        page.maxRetries = 0 // not set — must fall back to a sane default (3)
+
+        invokeHandleRetry0(PlainUrl("https://example.com"), page)
+
+        assertTrue(page.protocolStatus.isFailed, "A page without maxRetries must still be bounded")
+    }
+
+    @Test
+    fun `null page retry is bounded by the link retry budget`() {
+        val link = PlainUrl("https://example.com/null-page")
+
+        // No page at all: the first two attempts are re-queued...
+        invokeHandleRetry0(link, null)
+        invokeHandleRetry0(link, null)
+        invokeHandleRetry0(link, null)
+
+        // ... the fourth attempt (3 = default budget) stops the loop.
+        val attempts = readNullPageRetryCount(runner, link)
+        assertEquals(3, attempts)
+    }
+
+    private fun readNullPageRetryCount(runner: StreamingTaskRunner, url: UrlAware): Int? {
+        val field = StreamingTaskRunner::class.java.getDeclaredField("nullPageRetryCounts")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val map = field.get(runner) as MutableMap<UrlAware, Int>
+        return map[url]
+    }
+}

--- a/browser4-rest/src/main/kotlin/ai/platon/pulsar/rest/api/controller/SwarmController.kt
+++ b/browser4-rest/src/main/kotlin/ai/platon/pulsar/rest/api/controller/SwarmController.kt
@@ -43,6 +43,22 @@ class SwarmController(
     }
 
     /**
+     * Close the swarm session and abort all of its pending tasks.
+     *
+     * Pending tasks belong to the live swarm session and can never be consumed
+     * after it closes; without this cleanup they stay "queued" forever and leak
+     * across sessions. Closed tasks are marked as failed with a clear reason.
+     *
+     * @return The number of aborted pending tasks.
+     * */
+    @DeleteMapping
+    fun close(): Map<String, Any> {
+        val aborted = swarmService.closeSession()
+        logger.info("Swarm session closed, {} pending task(s) aborted", aborted)
+        return mapOf("closed" to true, "abortedPendingTasks" to aborted)
+    }
+
+    /**
      * Submit a URL to scrape or submit an X-SQL to execute
      *
      * @param payload The url to scrape or an X-SQL to execute

--- a/browser4-rest/src/main/kotlin/ai/platon/pulsar/rest/api/service/SwarmService.kt
+++ b/browser4-rest/src/main/kotlin/ai/platon/pulsar/rest/api/service/SwarmService.kt
@@ -1,5 +1,6 @@
 package ai.platon.pulsar.rest.api.service
 
+import ai.platon.pulsar.agentic.AgenticSession
 import ai.platon.pulsar.agentic.GenericAgenticSession
 import ai.platon.pulsar.agentic.tools.advanced.common.JsonlPersistence
 import ai.platon.pulsar.agentic.tools.advanced.crawl.QueryRequest
@@ -7,6 +8,7 @@ import ai.platon.pulsar.agentic.tools.advanced.crawl.ScrapeRequest
 import ai.platon.pulsar.agentic.tools.advanced.crawl.ScrapeResponse
 import ai.platon.pulsar.agentic.tools.advanced.crawl.common.ScrapeHyperlink
 import ai.platon.pulsar.agentic.tools.advanced.crawl.common.ScrapeAPIUtils
+import ai.platon.pulsar.common.B4Constants.SWARM_SESSION_ID
 import ai.platon.pulsar.rest.session.PulsarSessionManager
 import ai.platon.pulsar.common.ResourceStatus
 import ai.platon.pulsar.common.serialize.json.pulsarObjectMapper
@@ -31,7 +33,30 @@ class SwarmService(
 
     private val logger = LoggerFactory.getLogger(SwarmService::class.java)
 
-    val session get() = sessionManager.ensureSwarmSession().agenticSession
+    /**
+     * The id of the swarm session the pending tasks belong to. When the swarm
+     * session is closed and a new one is created, this id changes and all
+     * pending tasks of the old session are aborted — they can never be
+     * consumed again, and leaving them "queued" forever leaks them across
+     * sessions.
+     * */
+    @Volatile
+    private var swarmSessionId: Long = -1
+
+    val session: AgenticSession
+        get() {
+            val s = sessionManager.ensureSwarmSession().agenticSession
+            val previousId = swarmSessionId
+            if (previousId != -1L && previousId != s.id) {
+                logger.info(
+                    "Swarm session changed (#{} -> #{}), aborting pending tasks of the old session",
+                    previousId, s.id
+                )
+                abortPendingTasks("Swarm session was closed; task dropped")
+            }
+            swarmSessionId = s.id
+            return s
+        }
 
     /**
      * The response status index, the key is the status code, the value is the response's id.
@@ -129,6 +154,24 @@ class SwarmService(
                     logger.debug("Skipping expired swarm task {} during restore (created={})", id, response.createdTime)
                     return@restore
                 }
+
+                // Non-terminal entries can never resume after a restart: the
+                // worker state (hyperlinks, url pool entries) is gone, so a
+                // queued/processing task would sit in the cache forever and
+                // leak across sessions. Mark them as failed with a clear reason.
+                if (!response.isDone) {
+                    logger.info(
+                        "Swarm task {} was interrupted by a restart and cannot resume; marking as failed",
+                        id
+                    )
+                    response.statusCode = ResourceStatus.SC_GONE
+                    response.isDone = true
+                    response.finishTime = now
+                    response.lastModifiedTime = now
+                    response.message = response.message
+                        ?: "Task was interrupted by a restart and cannot resume. Re-submit the task to retry."
+                }
+
                 responseCache.put(id, response)
                 responseStatusIndex[response.statusCode].add(id)
             }
@@ -157,8 +200,9 @@ class SwarmService(
     }
 
     /**
-     * Transition swarm tasks that have been stuck in CREATED (queued) state
-     * for longer than [staleTaskTimeoutSeconds] to a TIMEOUT/failed state.
+     * Transition swarm tasks that have been stuck in a non-terminal state
+     * (CREATED/queued or picked up but never finished) for longer than
+     * [staleTaskTimeoutSeconds] to a TIMEOUT/failed state.
      *
      * This catches tasks whose workers hung during fetch (e.g. "Protocol not found"
      * for localhost URLs or other unreachable hosts) and never updated their status.
@@ -167,27 +211,33 @@ class SwarmService(
     private fun transitionStaleTasks() {
         val now = Instant.now()
         val staleCutoff = now.minusSeconds(staleTaskTimeoutSeconds)
-        val createdStatusCode = ResourceStatus.SC_CREATED
 
         val stale = responseCache.asMap().entries.filter {
             val r = it.value
-            r.statusCode == createdStatusCode
-                && !r.isDone
-                && r.createdTime?.isBefore(staleCutoff) == true
-                && r.startedTime == null // hasn't been picked up by a worker at all
+            // Use lastModifiedTime when available: a task picked up by a worker
+            // has a startedTime, so checking createdTime alone would never catch
+            // tasks whose workers hung mid-fetch. Every status/event update
+            // refreshes lastModifiedTime, so tasks that are actively progressing
+            // (e.g. waiting between bounded retry attempts) are never affected.
+            val lastTouched = r.lastModifiedTime ?: r.createdTime
+            !r.isDone
+                && lastTouched?.isBefore(staleCutoff) == true
         }
 
         for ((id, response) in stale) {
+            responseStatusIndex[response.statusCode]?.remove(id)
             response.statusCode = ResourceStatus.SC_REQUEST_TIMEOUT
             response.pageStatusCode = ProtocolStatusCodes.SC_REQUEST_TIMEOUT
             response.finishTime = now
             response.lastModifiedTime = now
             response.isDone = true
-            responseStatusIndex[createdStatusCode]?.remove(id)
+            response.message = response.message
+                ?: "Task timed out: no progress for ${staleTaskTimeoutSeconds}s. " +
+                "The worker may have hung during fetch. Re-submit the task to retry."
             responseStatusIndex[response.statusCode]?.add(id)
             persistence.append(response)
             logger.warn(
-                "Swarm task {} auto-timed-out after {}s in CREATED state " +
+                "Swarm task {} auto-timed-out after no progress for {}s " +
                 "(staleTaskTimeoutSeconds={}). Likely cause: worker hung during fetch.",
                 id, staleTaskTimeoutSeconds, staleTaskTimeoutSeconds
             )
@@ -195,7 +245,7 @@ class SwarmService(
 
         if (stale.isNotEmpty()) {
             logger.info(
-                "Transitioned {} stale swarm task(s) from CREATED to TIMEOUT " +
+                "Transitioned {} stale swarm task(s) to TIMEOUT " +
                 "(threshold: {}s)", stale.size, staleTaskTimeoutSeconds
             )
         }
@@ -205,14 +255,17 @@ class SwarmService(
      * Submit a scraping task
      * */
     fun submit(request: ScrapeRequest): String {
-        val hyperlink = createScrapeHyperlink(request)
-        responseCache.put(hyperlink.uuid, hyperlink.response)
-        hyperlink.response.id = hyperlink.uuid
-        persistence.append(hyperlink.response)
+        // Resolve the session BEFORE the task is cached: the session getter
+        // detects swarm session replacement and aborts pending tasks, and the
+        // freshly submitted task must never be aborted by that check.
         val s = session
         require(s is GenericAgenticSession) {
             "Expected GenericAgenticSession but got ${s::class.simpleName} (uuid=${s.uuid})"
         }
+        val hyperlink = createScrapeHyperlink(request, s)
+        responseCache.put(hyperlink.uuid, hyperlink.response)
+        hyperlink.response.id = hyperlink.uuid
+        persistence.append(hyperlink.response)
         s.submit(hyperlink)
         logger.debug("Swarm task submitted: {} sql={}", hyperlink.uuid, request.sql)
         return hyperlink.uuid
@@ -223,6 +276,52 @@ class SwarmService(
      * */
     fun submit(request: QueryRequest): String {
         return submit(ScrapeRequest(request.toSQL()))
+    }
+
+    /**
+     * Abort all pending (non-terminal) tasks with a clear failure reason.
+     *
+     * Pending tasks belong to a live swarm session: once that session is closed
+     * they can never be consumed again, so they must not stay "queued" forever
+     * (which also leaks them across sessions and restarts). This marks them as
+     * failed with [ResourceStatus.SC_GONE] and persists the transition.
+     *
+     * @param reason the human-readable reason to record in the response message
+     * @return the number of aborted tasks
+     */
+    fun abortPendingTasks(reason: String): Int {
+        val now = Instant.now()
+        val pending = responseCache.asMap().entries.filter { !it.value.isDone }
+
+        for ((id, response) in pending) {
+            responseStatusIndex[response.statusCode]?.remove(id)
+            response.statusCode = ResourceStatus.SC_GONE
+            response.pageStatusCode = ProtocolStatusCodes.SC_REQUEST_TIMEOUT
+            response.finishTime = now
+            response.lastModifiedTime = now
+            response.isDone = true
+            response.message = response.message ?: reason
+            responseStatusIndex[response.statusCode]?.add(id)
+            persistence.append(response)
+        }
+
+        if (pending.isNotEmpty()) {
+            logger.info("Aborted {} pending swarm task(s): {}", pending.size, reason)
+        }
+        return pending.size
+    }
+
+    /**
+     * Close the swarm session: abort its pending tasks and release the session.
+     * Called by the REST close endpoint (and indirectly by `swarm close`).
+     *
+     * @return the number of aborted pending tasks
+     */
+    fun closeSession(): Int {
+        val aborted = abortPendingTasks("Swarm session was closed; task dropped")
+        runCatching { sessionManager.deleteSession(SWARM_SESSION_ID) }
+            .onFailure { logger.warn("Failed to close the swarm session: {}", it.message) }
+        return aborted
     }
 
     /**
@@ -263,8 +362,8 @@ class SwarmService(
         )
     }
 
-    private fun createScrapeHyperlink(request: ScrapeRequest): ScrapeHyperlink {
-        return ScrapeHyperlinkFactory.create(request, session) { link ->
+    private fun createScrapeHyperlink(request: ScrapeRequest, agenticSession: AgenticSession): ScrapeHyperlink {
+        return ScrapeHyperlinkFactory.create(request, agenticSession) { link ->
             responseCache.put(link.uuid, link.response)
             responseStatusIndex[link.response.statusCode].add(link.uuid)
             persistence.append(link.response)

--- a/browser4-rest/src/main/kotlin/ai/platon/pulsar/rest/session/PulsarSessionManager.kt
+++ b/browser4-rest/src/main/kotlin/ai/platon/pulsar/rest/session/PulsarSessionManager.kt
@@ -932,8 +932,16 @@ class PulsarSessionManager(
                 sessionId, pulsarSession.id, pulsarSession.display
             )
 
-            // Close session
-            pulsarSession.close()
+            // Close the session AND deregister it from the context's session
+            // registry. A plain close() leaves a zombie session in
+            // context.sessions; `ensureSwarmSession` looks sessions up by label
+            // and would otherwise return the closed swarm session forever,
+            // leaving every new swarm task "queued" and never consumed.
+            runCatching { pulsarSession.context.closeSession(pulsarSession) }
+                .onFailure { e ->
+                    logger.warn("Failed to deregister session {}, falling back to plain close: {}", sessionId, e.message)
+                    pulsarSession.close()
+                }
             // Close the companion browser if it exists
             if (browser != null) {
                 // might be already closed by the session, but we ensure it's closed here to release resources

--- a/browser4-rest/src/test/kotlin/ai/platon/pulsar/rest/api/controller/SwarmControllerTest.kt
+++ b/browser4-rest/src/test/kotlin/ai/platon/pulsar/rest/api/controller/SwarmControllerTest.kt
@@ -56,6 +56,21 @@ class SwarmControllerTest {
     // -----------------------------------------------------------------
 
     @Test
+    fun closeAbortsPendingTasksAndReportsCount() {
+        val sessionManager = Mockito.mock(PulsarSessionManager::class.java)
+        val swarmService = Mockito.mock(SwarmService::class.java)
+        val controller = SwarmController(sessionManager, swarmService)
+
+        Mockito.`when`(swarmService.closeSession()).thenReturn(3)
+
+        val result = controller.close()
+
+        assertEquals(true, result["closed"])
+        assertEquals(3, result["abortedPendingTasks"])
+        verify(swarmService).closeSession()
+    }
+
+    @Test
     fun submitWithBlankPayloadThrowsIllegalArgumentException() {
         val sessionManager = Mockito.mock(PulsarSessionManager::class.java)
         val swarmService = Mockito.mock(SwarmService::class.java)

--- a/browser4-rest/src/test/kotlin/ai/platon/pulsar/rest/api/service/SwarmServicePersistenceTest.kt
+++ b/browser4-rest/src/test/kotlin/ai/platon/pulsar/rest/api/service/SwarmServicePersistenceTest.kt
@@ -1,8 +1,11 @@
 package ai.platon.pulsar.rest.api.service
 
+import ai.platon.pulsar.agentic.AgenticSession
 import ai.platon.pulsar.agentic.tools.advanced.common.JsonlPersistence
 import ai.platon.pulsar.agentic.tools.advanced.crawl.ScrapeResponse
+import ai.platon.pulsar.common.ResourceStatus
 import ai.platon.pulsar.common.serialize.json.pulsarObjectMapper
+import ai.platon.pulsar.rest.session.ManagedSession
 import ai.platon.pulsar.rest.session.PulsarSessionManager
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -10,6 +13,7 @@ import org.junit.jupiter.api.io.TempDir
 import org.mockito.Mockito
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
 
 class SwarmServicePersistenceTest {
 
@@ -25,7 +29,7 @@ class SwarmServicePersistenceTest {
         val task1 = ScrapeResponse(id = "t1", statusCode = 201, pageStatusCode = 200)
             .apply { lastModifiedTime = null; startedTime = null; finishTime = null }
         val task2 = ScrapeResponse(id = "t2", statusCode = 200, pageStatusCode = 200)
-            .apply { lastModifiedTime = null; startedTime = null; finishTime = null }
+            .apply { lastModifiedTime = null; startedTime = null; finishTime = null; isDone = true }
         Files.createDirectories(tempDir)
         Files.writeString(
             jsonlPath,
@@ -37,14 +41,32 @@ class SwarmServicePersistenceTest {
         invokeRestore(service, tempDir)
 
         assertEquals(2, service.responseCache.estimatedSize(), "should have 2 restored entries")
-        val restored1 = service.responseCache.getIfPresent("t1")
-        assertNotNull(restored1)
-        assertEquals("t1", restored1!!.id)
-        assertEquals(201, restored1.statusCode)
         val restored2 = service.responseCache.getIfPresent("t2")
         assertNotNull(restored2)
         assertEquals("t2", restored2!!.id)
         assertEquals(200, restored2.statusCode)
+        assertTrue(restored2.isDone)
+    }
+
+    @Test
+    fun `restoreFromDisk marks non-terminal tasks as failed`(@TempDir tempDir: Path) {
+        val jsonlPath = tempDir.resolve("swarm-tasks.jsonl")
+        val queuedTask = ScrapeResponse(id = "queued-1", statusCode = 201, pageStatusCode = 200)
+            .apply { lastModifiedTime = null; startedTime = null; finishTime = null }
+        Files.createDirectories(tempDir)
+        Files.writeString(jsonlPath, objectMapper.writeValueAsString(queuedTask) + "\n")
+
+        val service = TestableSwarmService(tempDir)
+        invokeRestore(service, tempDir)
+
+        val restored = service.responseCache.getIfPresent("queued-1")
+        assertNotNull(restored, "The task should be restored")
+        // A queued task can never resume after a restart (its worker state is
+        // gone) — it must not be revived as "queued" forever.
+        assertTrue(restored!!.isDone, "Non-terminal restored tasks must become terminal")
+        assertEquals(ResourceStatus.SC_GONE, restored.statusCode)
+        assertNotNull(restored.message)
+        assertTrue(restored.message!!.contains("restart"), "Message: ${restored.message}")
     }
 
     @Test
@@ -58,7 +80,7 @@ class SwarmServicePersistenceTest {
     fun `restoreFromDisk skips corrupt lines`(@TempDir tempDir: Path) {
         val jsonlPath = tempDir.resolve("swarm-tasks.jsonl")
         val task = ScrapeResponse(id = "good", statusCode = 200, pageStatusCode = 200)
-            .apply { lastModifiedTime = null; startedTime = null; finishTime = null }
+            .apply { lastModifiedTime = null; startedTime = null; finishTime = null; isDone = true }
         Files.createDirectories(tempDir)
         Files.writeString(
             jsonlPath,
@@ -96,9 +118,9 @@ class SwarmServicePersistenceTest {
         val task1 = ScrapeResponse(id = "i1", statusCode = 201, pageStatusCode = 200)
             .apply { lastModifiedTime = null; startedTime = null; finishTime = null }
         val task2 = ScrapeResponse(id = "i2", statusCode = 200, pageStatusCode = 200)
-            .apply { lastModifiedTime = null; startedTime = null; finishTime = null }
+            .apply { lastModifiedTime = null; startedTime = null; finishTime = null; isDone = true }
         val task3 = ScrapeResponse(id = "i3", statusCode = 200, pageStatusCode = 200)
-            .apply { lastModifiedTime = null; startedTime = null; finishTime = null }
+            .apply { lastModifiedTime = null; startedTime = null; finishTime = null; isDone = true }
         Files.createDirectories(tempDir)
         Files.writeString(
             jsonlPath,
@@ -110,8 +132,124 @@ class SwarmServicePersistenceTest {
         val service = TestableSwarmService(tempDir)
         invokeRestore(service, tempDir)
 
-        assertEquals(1, getStatusIndexCount(service, 201), "should have 1 task with status 201")
+        // The queued task (201) becomes failed (GONE) during restore.
+        assertEquals(1, getStatusIndexCount(service, ResourceStatus.SC_GONE), "should have 1 task with status GONE")
         assertEquals(2, getStatusIndexCount(service, 200), "should have 2 tasks with status 200")
+    }
+
+    // -----------------------------------------------------------------
+    // Pending task abort (swarm close cleanup)
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `abortPendingTasks aborts only non-terminal tasks`(@TempDir tempDir: Path) {
+        val service = TestableSwarmService(tempDir)
+
+        val queued = ScrapeResponse(id = "p1", statusCode = 201, pageStatusCode = 200)
+        service.responseCache.put("p1", queued)
+        val processing = ScrapeResponse(id = "p2", statusCode = 202, pageStatusCode = 200)
+        service.responseCache.put("p2", processing)
+        val done = ScrapeResponse(id = "p3", statusCode = 200, pageStatusCode = 200)
+            .apply { isDone = true }
+        service.responseCache.put("p3", done)
+
+        val aborted = service.abortPendingTasks("Swarm session was closed; task dropped")
+
+        assertEquals(2, aborted, "Only the two non-terminal tasks should be aborted")
+        assertTrue(queued.isDone)
+        assertEquals(ResourceStatus.SC_GONE, queued.statusCode)
+        assertNotNull(queued.message)
+        assertTrue(processing.isDone)
+        assertEquals(ResourceStatus.SC_GONE, processing.statusCode)
+        assertTrue(done.isDone)
+        assertEquals(200, done.statusCode, "Terminal tasks must not be touched")
+    }
+
+    @Test
+    fun `closeSession aborts pending tasks and deletes the swarm session`(@TempDir tempDir: Path) {
+        val sessionManager = Mockito.mock(PulsarSessionManager::class.java)
+        Mockito.`when`(sessionManager.deleteSession("SWARM")).thenReturn(true)
+        val service = TestableSwarmService(tempDir, sessionManager)
+
+        val queued = ScrapeResponse(id = "c1", statusCode = 201, pageStatusCode = 200)
+        service.responseCache.put("c1", queued)
+
+        val aborted = service.closeSession()
+
+        assertEquals(1, aborted)
+        assertTrue(queued.isDone)
+        assertEquals(ResourceStatus.SC_GONE, queued.statusCode)
+        Mockito.verify(sessionManager).deleteSession("SWARM")
+    }
+
+    // -----------------------------------------------------------------
+    // Session replacement aborts pending tasks (issue #577)
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `session replacement aborts pending tasks of the old session`(@TempDir tempDir: Path) {
+        val sessionManager = Mockito.mock(PulsarSessionManager::class.java)
+        val session1 = Mockito.mock(AgenticSession::class.java)
+        val session2 = Mockito.mock(AgenticSession::class.java)
+        Mockito.`when`(session1.id).thenReturn(1L)
+        Mockito.`when`(session2.id).thenReturn(2L)
+        val managed1 = ManagedSession(sessionId = "SWARM", agenticSession = session1, capabilities = emptyMap())
+        val managed2 = ManagedSession(sessionId = "SWARM", agenticSession = session2, capabilities = emptyMap())
+        Mockito.`when`(sessionManager.ensureSwarmSession()).thenReturn(managed1, managed2)
+
+        val service = TestableSwarmService(tempDir, sessionManager)
+        assertSame(session1, service.session, "First access resolves the current swarm session")
+
+        // A task submitted under session 1 ...
+        val queued = ScrapeResponse(id = "r1", statusCode = 201, pageStatusCode = 200)
+        service.responseCache.put("r1", queued)
+
+        // ... is aborted when the session is replaced (closed and recreated).
+        assertSame(session2, service.session, "Second access resolves the replacement session")
+        assertTrue(queued.isDone, "Pending tasks of the old session must become terminal")
+        assertEquals(ResourceStatus.SC_GONE, queued.statusCode)
+        assertNotNull(queued.message)
+    }
+
+    // -----------------------------------------------------------------
+    // Stale task transition (worker hung / never picked up)
+    // -----------------------------------------------------------------
+
+    @Test
+    fun `transitionStaleTasks times out tasks with no progress`(@TempDir tempDir: Path) {
+        val service = TestableSwarmService(tempDir)
+        redirectPersistenceFile(service, tempDir)
+        service.staleTaskTimeoutSeconds = 120
+        val now = Instant.now()
+
+        // Never picked up by a worker (createdTime only).
+        val neverPicked = ScrapeResponse(id = "s1", statusCode = 201, pageStatusCode = 200)
+            .apply { createdTime = now.minusSeconds(300); lastModifiedTime = null; startedTime = null }
+        // Picked up by a worker but hung mid-fetch (startedTime set, no updates).
+        val hungWorker = ScrapeResponse(id = "s2", statusCode = 201, pageStatusCode = 200)
+            .apply { createdTime = now.minusSeconds(300); lastModifiedTime = now.minusSeconds(200); startedTime = now.minusSeconds(200) }
+        // Actively progressing (recent updates) — must NOT be transitioned.
+        val active = ScrapeResponse(id = "s3", statusCode = 201, pageStatusCode = 200)
+            .apply { createdTime = now.minusSeconds(300); lastModifiedTime = now; startedTime = now.minusSeconds(200) }
+        // Terminal tasks are not touched.
+        val done = ScrapeResponse(id = "s4", statusCode = 200, pageStatusCode = 200)
+            .apply { isDone = true; lastModifiedTime = null; createdTime = now.minusSeconds(400) }
+
+        service.responseCache.put("s1", neverPicked)
+        service.responseCache.put("s2", hungWorker)
+        service.responseCache.put("s3", active)
+        service.responseCache.put("s4", done)
+
+        invokeTransitionStaleTasks(service)
+
+        assertTrue(neverPicked.isDone, "Never-picked tasks must be transitioned")
+        assertEquals(ResourceStatus.SC_REQUEST_TIMEOUT, neverPicked.statusCode)
+        assertTrue(hungWorker.isDone, "Hung-worker tasks must be transitioned")
+        assertEquals(ResourceStatus.SC_REQUEST_TIMEOUT, hungWorker.statusCode)
+        assertFalse(active.isDone, "Progressing tasks must not be transitioned")
+        assertEquals(201, active.statusCode)
+        assertTrue(done.isDone)
+        assertEquals(200, done.statusCode, "Terminal tasks must not be touched")
     }
 
     // -----------------------------------------------------------------
@@ -120,13 +258,25 @@ class SwarmServicePersistenceTest {
 
     /** Points the service at a temp directory then calls restoreFromDisk. */
     private fun invokeRestore(service: SwarmService, tempDir: Path) {
+        redirectPersistenceFile(service, tempDir)
+
+        // restoreFromDisk is @PostConstruct, call it via reflection
+        val method = SwarmService::class.java.getDeclaredMethod("restoreFromDisk")
+        method.isAccessible = true
+        method.invoke(service)
+    }
+
+    /** Redirects the service's JsonlPersistence to a temp directory. */
+    private fun redirectPersistenceFile(service: SwarmService, tempDir: Path) {
         // Redirect JsonlPersistence to temp dir
         val fileField = JsonlPersistence::class.java.getDeclaredField("file")
         fileField.isAccessible = true
         fileField.set(service.persistence, tempDir.resolve("swarm-tasks.jsonl"))
+    }
 
-        // restoreFromDisk is @PostConstruct, call it via reflection
-        val method = SwarmService::class.java.getDeclaredMethod("restoreFromDisk")
+    /** Invokes the private transitionStaleTasks via reflection. */
+    private fun invokeTransitionStaleTasks(service: SwarmService) {
+        val method = SwarmService::class.java.getDeclaredMethod("transitionStaleTasks")
         method.isAccessible = true
         method.invoke(service)
     }
@@ -143,7 +293,8 @@ class SwarmServicePersistenceTest {
     }
 
     /** Minimal subclass to provide the mocked session manager. */
-    private class TestableSwarmService(tempDir: Path) : SwarmService(
-        Mockito.mock(PulsarSessionManager::class.java)
-    )
+    private class TestableSwarmService(
+        tempDir: Path,
+        sessionManager: PulsarSessionManager = Mockito.mock(PulsarSessionManager::class.java),
+    ) : SwarmService(sessionManager)
 }

--- a/browser4-rest/src/test/kotlin/ai/platon/pulsar/rest/mcp/service/PulsarSessionManagerTest.kt
+++ b/browser4-rest/src/test/kotlin/ai/platon/pulsar/rest/mcp/service/PulsarSessionManagerTest.kt
@@ -147,6 +147,24 @@ class PulsarSessionManagerTest {
     }
 
     @Test
+    fun ensureSwarmSessionCreatesFreshSessionAfterDelete() {
+        // Regression guard for issue #577: a closed swarm session must never be
+        // resurrected. If it were, every new swarm task would be submitted to a
+        // closed session and stay "queued" forever.
+        val first = sessionManager.ensureSwarmSession()
+
+        assertTrue(sessionManager.deleteSession(SWARM_SESSION_ID))
+
+        val second = sessionManager.ensureSwarmSession()
+        assertNotNull(second)
+        assertNotSame(
+            first.agenticSession,
+            second.agenticSession,
+            "A closed swarm session must be replaced with a fresh session"
+        )
+    }
+
+    @Test
     fun getAllSessionsDoesNotCreateEnsureDefaultSessionOnDemand() {
         val sessions = sessionManager.getAllSessions()
 

--- a/cli/browser4-cli/src/help.rs
+++ b/cli/browser4-cli/src/help.rs
@@ -1451,6 +1451,8 @@ pub fn generate_command_help(cmd: &CommandDef) -> String {
     if cmd.name == "swarm-close" {
         lines.push("Notes:".to_string());
         lines.push("  - Closes the active swarm session and releases browser resources.".to_string());
+        lines.push("  - Pending (queued/processing) tasks are aborted and marked as failed (closed),".to_string());
+        lines.push("    so they don't stay \"queued\" forever and leak across sessions.".to_string());
         lines.push("  - Equivalent to `close` when a swarm session is active.".to_string());
         lines.push(String::new());
         lines.push("Examples:".to_string());

--- a/cli/browser4-cli/src/http.rs
+++ b/cli/browser4-cli/src/http.rs
@@ -710,6 +710,24 @@ pub async fn submit_swarm_query(
     .await
 }
 
+/// Close the swarm session through `SwarmController.close()`.
+///
+/// The backend aborts all pending (non-terminal) tasks of the swarm session so
+/// they don't stay "queued" forever and leak across sessions. Returns the
+/// backend payload (e.g. `{"closed":true,"abortedPendingTasks":3}`).
+pub async fn close_swarm_session(
+    client: &Client,
+    base_url: &str,
+) -> Result<String, String> {
+    let url = build_endpoint_url(base_url, "/api/swarm");
+    send_rest_request(
+        client
+            .delete(url)
+            .timeout(std::time::Duration::from_secs(10)),
+    )
+    .await
+}
+
 /// Read swarm task status through `SwarmController.getStatus(id)`.
 ///
 /// Uses a short timeout (5 s) so that a single unreachable task does not block

--- a/cli/browser4-cli/src/main.rs
+++ b/cli/browser4-cli/src/main.rs
@@ -59,10 +59,11 @@ use help::{
 };
 use http::{
     call_tool, call_tool_with_result, call_tool_with_timeout_override, cancel_crawl,
-    clear_all_crawls, clear_crawls, crawl_request_timeout, get_command_result,
-    get_command_status, get_crawl_result, get_crawl_status, get_swarm_result,
-    get_swarm_status, is_stale_session_error, make_client, submit_batch_commands,
-    submit_crawl, submit_plain_command, submit_swarm_payload, submit_swarm_query, CallToolResult,
+    clear_all_crawls, clear_crawls, close_swarm_session, crawl_request_timeout,
+    get_command_result, get_command_status, get_crawl_result, get_crawl_status,
+    get_swarm_result, get_swarm_status, is_stale_session_error, make_client,
+    submit_batch_commands, submit_crawl, submit_plain_command, submit_swarm_payload,
+    submit_swarm_query, CallToolResult,
 };
 use managed_processes::{
     read_managed_server_processes, stop_browser4_server_forcibly, ManagedServerProcess,
@@ -9414,6 +9415,33 @@ async fn handle_swarm_create(
     Ok(())
 }
 
+/// Mark locally tracked pending swarm tasks as "failed (closed)".
+///
+/// Pending tasks (never polled, queued, or processing) can never complete
+/// after their swarm session closes — the backend drops them, so the local
+/// tracking must reflect that instead of showing them "queued" forever.
+/// Completed/failed tasks are left untouched.
+///
+/// Returns the number of tasks marked.
+fn mark_local_swarm_tasks_closed(list: &mut state::AsyncTaskList) -> usize {
+    let mut marked = 0usize;
+    for t in list
+        .tasks
+        .iter_mut()
+        .filter(|t| t.command == "swarm-submit" || t.command == "swarm-query")
+    {
+        let is_pending = t.last_status.is_empty()
+            || t.last_status == "queued"
+            || t.last_status == "processing"
+            || t.last_status == "pending";
+        if is_pending {
+            t.last_status = "failed (closed)".to_string();
+            marked += 1;
+        }
+    }
+    marked
+}
+
 async fn handle_swarm_close(
     client: &Client,
     base_url: &str,
@@ -9432,6 +9460,22 @@ async fn handle_swarm_close(
     };
     json_field("session_id", json!(&session_id));
 
+    // Ask the backend to abort pending swarm tasks BEFORE closing the session,
+    // so they don't stay "queued" forever and leak across sessions. Best-effort:
+    // older backends without the DELETE /api/swarm endpoint (or an unreachable
+    // backend) must not break the close itself.
+    let mut aborted_pending: Option<i64> = None;
+    match close_swarm_session(client, base_url).await {
+        Ok(payload) => {
+            if let Ok(parsed) = serde_json::from_str::<Value>(&payload) {
+                aborted_pending = parsed.get("abortedPendingTasks").and_then(|v| v.as_i64());
+            }
+        }
+        Err(e) => {
+            eprintln!("Note: could not clean up pending swarm tasks on the backend: {e}");
+        }
+    }
+
     // Count tracked swarm tasks before closing (for the summary).
     let existing = read_async_tasks(None);
     let swarm_task_count = existing
@@ -9439,6 +9483,12 @@ async fn handle_swarm_close(
         .iter()
         .filter(|t| t.command == "swarm-submit" || t.command == "swarm-query")
         .count();
+
+    // Mark locally tracked pending tasks as failed (closed) so `swarm list`
+    // reflects the cleanup even when the backend was unreachable.
+    let mut list = existing;
+    let locally_closed = mark_local_swarm_tasks_closed(&mut list);
+    let _ = write_async_tasks(&list, None);
 
     // Close the swarm session — ignore errors if already closed.
     let _ = call_tool(
@@ -9451,11 +9501,22 @@ async fn handle_swarm_close(
     clear_state(None, effective_name);
 
     json_field("closed", json!(true));
+    json_field("aborted_pending_tasks", json!(aborted_pending.unwrap_or(0)));
     if swarm_task_count > 0 {
-        cli_println!(
-            "Swarm session closed. Browser terminated. {} tracked task(s) retained for history. Use `swarm list --clear` to remove.",
-            swarm_task_count
-        );
+        let cleanup_msg = match aborted_pending {
+            Some(n) if n > 0 => format!(" {n} pending task(s) aborted on the backend."),
+            Some(_) => " All pending tasks were already finished.".to_string(),
+            None => String::new(),
+        };
+        if locally_closed > 0 {
+            cli_println!(
+                "Swarm session closed. Browser terminated.{cleanup_msg} {locally_closed} locally tracked pending task(s) marked as failed (closed)."
+            );
+        } else {
+            cli_println!(
+                "Swarm session closed. Browser terminated.{cleanup_msg} {swarm_task_count} tracked task(s) retained for history. Use `swarm list --clear` to remove."
+            );
+        }
         json_field("tracked_tasks_retained", json!(swarm_task_count));
     } else {
         cli_println!("Swarm session closed. Browser terminated.");
@@ -9925,13 +9986,28 @@ async fn handle_swarm_result(
         "resultSet": result_set,
         "pageContentBytes": parsed.get("pageContentBytes").unwrap_or(&json!(null)),
         "error": parsed.get("error").unwrap_or(&json!(null)),
+        "message": parsed.get("message").unwrap_or(&json!(null)),
+        "statusCode": parsed.get("statusCode").unwrap_or(&json!(null)),
     });
     cli_println!("{}", serde_json::to_string_pretty(&payload).unwrap_or_default());
 
-    // Guide users when resultSet is empty — distinguish "page never fetched"
-    // from "page fetched but nothing extracted" so the hint doesn't mislead
-    // `swarm query` users whose task was silently dropped/evicted.
-    if is_empty && !parsed.get("error").and_then(|v| v.as_str()).map(|s| !s.is_empty()).unwrap_or(false) {
+    // Surface the failure reason for terminal non-success tasks so a completed
+    // task with an empty resultSet explains WHY it is empty (page never
+    // fetched, aborted, timed out, ...) instead of guessing.
+    let has_message = parsed
+        .get("message")
+        .and_then(|v| v.as_str())
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+    if is_empty && has_message {
+        cli_println!("Note: {}", parsed["message"].as_str().unwrap_or_default());
+    }
+
+    // Guide users when resultSet is empty and no explicit failure reason was
+    // provided — distinguish "page never fetched" from "page fetched but
+    // nothing extracted" so the hint doesn't mislead `swarm query` users whose
+    // task was silently dropped/evicted.
+    if is_empty && !has_message && !parsed.get("error").and_then(|v| v.as_str()).map(|s| !s.is_empty()).unwrap_or(false) {
         let page_content_bytes = parsed
             .get("pageContentBytes")
             .and_then(|v| v.as_i64())
@@ -22726,6 +22802,91 @@ mod tests {
 
         let result = swarm_wait_for_jobs(&client, base_url, &[]).await;
         assert!(result.is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // swarm close cleanup tests (issue #577)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn mark_local_swarm_tasks_closed_marks_only_pending_swarm_tasks() {
+        let mut list = state::AsyncTaskList {
+            tasks: vec![
+                state::AsyncTaskEntry {
+                    task_id: "t1".to_string(),
+                    command: "swarm-query".to_string(),
+                    description: "https://example.com".to_string(),
+                    submitted_at: "s1".to_string(),
+                    last_status: "queued".to_string(),
+                    completed_at: None,
+                },
+                state::AsyncTaskEntry {
+                    task_id: "t2".to_string(),
+                    command: "swarm-submit".to_string(),
+                    description: "https://example.org".to_string(),
+                    submitted_at: "s2".to_string(),
+                    last_status: "processing".to_string(),
+                    completed_at: None,
+                },
+                state::AsyncTaskEntry {
+                    task_id: "t3".to_string(),
+                    command: "swarm-submit".to_string(),
+                    description: "https://example.net".to_string(),
+                    submitted_at: "s3".to_string(),
+                    last_status: String::new(), // never polled
+                    completed_at: None,
+                },
+                state::AsyncTaskEntry {
+                    task_id: "t4".to_string(),
+                    command: "swarm-query".to_string(),
+                    description: "https://example.edu".to_string(),
+                    submitted_at: "s4".to_string(),
+                    last_status: "completed".to_string(),
+                    completed_at: Some("c4".to_string()),
+                },
+                state::AsyncTaskEntry {
+                    task_id: "t5".to_string(),
+                    command: "swarm-query".to_string(),
+                    description: "https://example.io".to_string(),
+                    submitted_at: "s5".to_string(),
+                    last_status: "failed (timeout)".to_string(),
+                    completed_at: Some("c5".to_string()),
+                },
+                state::AsyncTaskEntry {
+                    task_id: "t6".to_string(),
+                    command: "crawl".to_string(),
+                    description: "https://example.xyz".to_string(),
+                    submitted_at: "s6".to_string(),
+                    last_status: "queued".to_string(),
+                    completed_at: None,
+                },
+            ],
+        };
+
+        let marked = mark_local_swarm_tasks_closed(&mut list);
+
+        assert_eq!(marked, 3, "pending swarm tasks must be marked");
+        let status = |id: &str| {
+            list.tasks
+                .iter()
+                .find(|t| t.task_id == id)
+                .unwrap()
+                .last_status
+                .clone()
+        };
+        assert_eq!(status("t1"), "failed (closed)");
+        assert_eq!(status("t2"), "failed (closed)");
+        assert_eq!(status("t3"), "failed (closed)");
+        assert_eq!(status("t4"), "completed", "completed tasks must be untouched");
+        assert_eq!(status("t5"), "failed (timeout)", "failed tasks must be untouched");
+        assert_eq!(status("t6"), "queued", "non-swarm tasks must be untouched");
+    }
+
+    #[test]
+    fn mark_local_swarm_tasks_closed_handles_empty_list() {
+        let mut list = state::AsyncTaskList::default();
+        let marked = mark_local_swarm_tasks_closed(&mut list);
+        assert_eq!(marked, 0);
     }
 
     // =========================================================================

--- a/cli/browser4-cli/tests/e2e/constants.rs
+++ b/cli/browser4-cli/tests/e2e/constants.rs
@@ -94,6 +94,8 @@ Environment variables:
   BROWSER4_E2E_FIXTURE_HOST    Host the Browser4 container uses to reach the
                                fixture HTTP server (default: 127.0.0.1)
   BROWSER4_E2E_CLI_TIMEOUT_SECS Override per-command timeout in seconds
+                               (commands with --wait default to 300 s, matching
+                               the CLI's built-in wait cap; everything else 120 s)
   BROWSER4_E2E_USE_MAVEN_STARTUP Set to 1/true/yes/on for Maven startup
   BROWSER4_E2E_FORCE_REMOTE_BUNDLE Set to 1/true/yes/on to download runtime
                                bundle from GitHub (equiv. --force-remote-bundle)

--- a/cli/browser4-cli/tests/e2e/mod.rs
+++ b/cli/browser4-cli/tests/e2e/mod.rs
@@ -284,6 +284,21 @@ fn serve_fixture_request(mut stream: std::net::TcpStream, pages: Arc<FixturePage
         .and_then(|line| line.split_whitespace().nth(1))
         .unwrap_or("/");
 
+    // Slow endpoints used by the swarm concurrency scenario (issue #577):
+    // they hold a browser slot for several seconds so a small privacy context
+    // pool is deterministically exhausted by concurrent tasks.
+    if path.starts_with("/slow/") {
+        std::thread::sleep(Duration::from_secs(6));
+        let slow_body = pages.interactive_html.clone();
+        let slow_response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            slow_body.len(),
+            slow_body
+        );
+        let _ = stream.write_all(slow_response.as_bytes());
+        return;
+    }
+
     let (status, content_type, body) = if path == INTERACTIVE_PATH || path == "/" {
         (
             "200 OK",
@@ -630,6 +645,8 @@ struct MockBrowser4State {
     health_status: Option<(u16, String, String)>, // (status_code, content_type, body)
     close_session_calls: Vec<String>,
     close_all_sessions_calls: Vec<serde_json::Value>,
+    /// Number of DELETE /api/swarm calls (swarm close cleanup, issue #577).
+    swarm_close_calls: u32,
     crawl_submissions: Vec<serde_json::Value>,
     crawl_cancel_calls: Vec<String>,
     crawl_clear_calls: u32,
@@ -1206,6 +1223,18 @@ fn serve_mock_browser4_request(mut stream: TcpStream, state: Arc<Mutex<MockBrows
                 "200 OK",
                 "application/json",
                 &serde_json::json!(task_id).to_string(),
+            );
+        }
+        _ if method == "DELETE" && route == "/api/swarm" => {
+            state
+                .lock()
+                .expect("mock Browser4 state mutex poisoned")
+                .swarm_close_calls += 1;
+            write_http_response(
+                &mut stream,
+                "200 OK",
+                "application/json",
+                r#"{"closed":true,"abortedPendingTasks":0}"#,
             );
         }
         _ if method == "GET"
@@ -1945,6 +1974,12 @@ impl E2ECtx {
         format!("{}{}", self.fixture_base_url, KEYBOARD_PATH)
     }
 
+    /// A slow fixture URL (served after a fixed delay) used to hold browser
+    /// slots in the swarm concurrency scenario.
+    fn slow_url(&self, i: usize) -> String {
+        format!("{}/slow/{}", self.fixture_base_url, i)
+    }
+
     fn clear_step_timings(&mut self) {
         self.step_timings.clear();
     }
@@ -2455,6 +2490,14 @@ fn cli_process_timeout(full_args: &[&str]) -> Duration {
 
     if full_args.iter().any(|arg| *arg == "list") {
         Duration::from_secs(240)
+    } else if full_args.iter().any(|arg| *arg == "--wait") {
+        // `swarm query --wait` polls until all jobs reach a terminal state,
+        // up to the CLI's own 5-minute cap (main.rs wait_for_swarm_jobs
+        // max_wait = 300 s). The harness must not kill the command before the
+        // CLI gives up: with a small privacy context pool, concurrent swarm
+        // jobs legitimately wait through 30-44 s retry delays, and a tighter
+        // harness timeout turns a valid run into a false failure.
+        Duration::from_secs(300)
     } else {
         Duration::from_secs(120)
     }

--- a/cli/browser4-cli/tests/e2e/scenarios/mock_server.rs
+++ b/cli/browser4-cli/tests/e2e/scenarios/mock_server.rs
@@ -3416,6 +3416,10 @@ pub(super) fn test_swarm_close_session(ctx: &mut E2ECtx) {
         "Expected close_session call with SWARM session ID, got {:?}",
         snapshot.close_session_calls
     );
+    assert_eq!(
+        snapshot.swarm_close_calls, 1,
+        "swarm close must ask the backend to abort pending tasks (DELETE /api/swarm)"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/browser4-cli/tests/e2e/scenarios/mod.rs
+++ b/cli/browser4-cli/tests/e2e/scenarios/mod.rs
@@ -215,6 +215,16 @@ pub(crate) const SCENARIOS: &[ScenarioDef] = &[
         level: ScenarioLevel::Extended,
     },
     ScenarioDef {
+        name: "test_e2e_swarm_concurrency_bounded_completion_live",
+        short_name: "test_swarm_concurrency_bounded_completion_live",
+        requires_browser4: true,
+        restart_browser4: false,
+        test_count: 1,
+        test_fn: swarm::test_swarm_concurrency_bounded_completion_live,
+        group: Some("swarm"),
+        level: ScenarioLevel::Extended,
+    },
+    ScenarioDef {
         name: "test_e2e_crawl_submission_live",
         short_name: "test_crawl_submission_live",
         requires_browser4: true,

--- a/cli/browser4-cli/tests/e2e/scenarios/swarm.rs
+++ b/cli/browser4-cli/tests/e2e/scenarios/swarm.rs
@@ -1,5 +1,118 @@
 use crate::*;
 
+pub(super) fn test_swarm_concurrency_bounded_completion_live(ctx: &mut E2ECtx) {
+    reset_cli_artifacts(ctx);
+
+    // Reproduces issue #577: 5 concurrent swarm jobs against a small privacy
+    // context pool. The pool is pinned to 2 contexts x 1 tab and the fixture
+    // URLs are slow (6 s each), so the pool is deterministically exhausted:
+    // the extra jobs hit the PrivacyException path that used to retry forever
+    // ("Trying 1th 43s later" in the logs) or be reported "completed" with an
+    // empty resultSet. With the fixes, all jobs must reach a terminal state
+    // with fetched data within the bounded `--wait` window.
+    let create_result = run_command(
+        ctx,
+        &[
+            "swarm",
+            "create",
+            "--profile-mode=TEMPORARY",
+            "--max-open-tabs=1",
+            "--max-browser-contexts=2",
+            "--display-mode=HEADLESS",
+        ],
+    );
+    let create_output = strip_snapshot_output(&create_result.stdout);
+    assert!(
+        create_output.contains("Swarm session created:"),
+        "Expected swarm session creation output in:\n{}",
+        create_result.stdout
+    );
+
+    let urls = [
+        ctx.slow_url(1),
+        ctx.slow_url(2),
+        ctx.slow_url(3),
+        ctx.slow_url(4),
+        ctx.slow_url(5),
+    ];
+    let seed_file = ctx.workspace_dir.join("swarm-concurrency-seeds.txt");
+    std::fs::write(&seed_file, urls.join("\n")).expect("write swarm concurrency seed file");
+    let seed_arg = format!("--seed-file={}", seed_file.to_string_lossy());
+    // NOTE: @url is substituted as an already-quoted value, so it must NOT be
+    // wrapped in quotes here (the issue's repro SQL uses the same pattern).
+    let sql = "select dom_base_uri(dom) as url from load_and_select(@url, ':root')";
+    let sql_arg = format!("--sql={sql}");
+
+    let query_result = run_command(ctx, &["swarm", "query", &seed_arg, &sql_arg, "--wait"]);
+    let query_output = strip_snapshot_output(&query_result.stdout);
+    assert!(
+        query_output.contains("All 5 job(s) completed"),
+        "Expected all 5 concurrent jobs to complete within the bounded wait window.\n\
+         The fix must prevent unbounded retries and queued-forever tasks.\n\
+         swarm query output:\n{}",
+        query_result.stdout
+    );
+
+    // Every completed job must contain fetched data. This catches the other
+    // half of issue #577: jobs reported "completed" with an empty resultSet
+    // and pageContentBytes = 0 (the page was never fetched). Parse the task
+    // ids printed by `swarm query` and verify each resultSet is non-empty and
+    // references its URL.
+    let task_ids: Vec<String> = query_output
+        .lines()
+        .filter_map(|line| {
+            line.trim()
+                .strip_prefix("Query Submitted: ")
+                .and_then(|rest| rest.split(" -> Task ID: ").nth(1))
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(str::to_string)
+        })
+        .collect();
+    assert_eq!(
+        task_ids.len(),
+        urls.len(),
+        "Expected {} submitted task ids in swarm query output:\n{}",
+        urls.len(),
+        query_result.stdout
+    );
+
+    for (task_id, expected_url) in task_ids.iter().zip(&urls) {
+        let result_payload = wait_for_swarm_result(ctx, task_id, 30_000);
+        let result_set = result_payload
+            .get("resultSet")
+            .and_then(|v| v.as_array())
+            .unwrap_or_else(|| {
+                panic!(
+                    "Expected non-null resultSet array for task '{task_id}', got:\n{result_payload}"
+                )
+            });
+        assert!(
+            !result_set.is_empty(),
+            "Expected non-empty resultSet for task '{task_id}' — the page must actually be fetched.\n\
+             (issue #577: completed jobs used to return empty resultSet + pageContentBytes 0)\n{result_payload}"
+        );
+        let found_url = result_set.iter().filter_map(|row| {
+            row.get("url").and_then(|v| v.as_str())
+        }).any(|u| u.trim() == expected_url.trim());
+        assert!(
+            found_url,
+            "Expected resultSet of task '{task_id}' to reference '{}', got:\n{result_payload}",
+            expected_url
+        );
+    }
+
+    // Every submitted job must have reached a terminal state.
+    let list_result = run_command(ctx, &["swarm", "list"]);
+    let list_output = strip_snapshot_output(&list_result.stdout);
+    assert!(
+        !list_output.contains("queued") && !list_output.contains("processing"),
+        "No job should remain queued/processing after completion. swarm list:\n{list_output}"
+    );
+
+    run_command(ctx, &["swarm", "close"]);
+}
+
 pub(super) fn test_swarm_submission_commands_live(ctx: &mut E2ECtx) {
     reset_cli_artifacts(ctx);
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,29 +1,17 @@
 {
   "name": "browser4-cli",
-  "version": "0.1.6",
+  "version": "4.13.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browser4-cli",
-      "version": "0.1.6",
+      "version": "4.13.9",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "browser4-cli": "^0.1.5"
-      },
       "bin": {
         "browser4": "bin/browser4-cli.js",
         "browser4-cli": "bin/browser4-cli.js"
-      }
-    },
-    "node_modules/browser4-cli": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/browser4-cli/-/browser4-cli-0.1.5.tgz",
-      "integrity": "sha512-1QRrfDT93UMt5OPjQWSz82c4okiDgapRO7MgMTpru0UMwxRT+R+tM4QfNi4z3vZaOfH0guWdEYnozjD+ca3w0Q==",
-      "hasInstallScript": true,
-      "bin": {
-        "browser4": "bin/browser4-cli.js"
       }
     }
   }


### PR DESCRIPTION
Fixes #577

## Summary

Swarm scraping was unreliable: jobs stayed `queued` and were never consumed, old tasks leaked across sessions/restarts, completed jobs returned empty results, and the `PrivacyException` crawl-retry path retried forever (`FetchTask.nRetries` was never incremented). This PR guarantees every swarm task reaches a terminal state — success, bounded failure, or timeout — with the real reason reported.

## Changes

### Backend
- **`StreamingTaskRunner`** — the streaming loop now advances `page.fetchRetries` (previously never incremented, so the retry budget never tripped) and tracks a separate budget for null-page retries; exhausted budgets mark the page failed (`SC_REQUEST_TIMEOUT`) instead of re-queueing forever. The repeated-cancel path gets the same budget. `maxRetriesOf()` uses the page's budget, falls back to the link's `nMaxRetry`, then a default of 3.
- **`StreamingTaskLoop`** — restarts the task runner if it exits unexpectedly while the loop is still running, re-resolving the live SWARM session so the URL pool keeps being consumed.
- **`SwarmService`** — tracks `swarmSessionId`; aborts pending tasks when the session is replaced or closed (`DELETE /api/swarm`, tasks marked `SC_GONE` with reason and persisted); marks non-terminal tasks failed on restore after a restart; stale-task timeout now keys off `lastModifiedTime` so hung workers are caught.
- **`AgenticContexts` / `PulsarSessionManager`** — closed SWARM sessions are removed from the context registry so `ensureSwarmSession` never resurrects a zombie session.
- **`XSQLScrapeHyperlink`** — retrying/canceled tasks stay non-terminal (emit `retry`); tasks whose page was never fetched now fail with `SC_EXPECTATION_FAILED` and a clear reason instead of "completing" with an empty `resultSet`.

### CLI
- **`swarm close`** — asks the backend to abort pending tasks (best-effort against older backends), marks locally tracked pending tasks as `failed (closed)`, and reports the counts.
- **`swarm result`** — surfaces `message`/`statusCode` so an empty result explains why.

### E2E
- New live scenario `test_e2e_swarm_concurrency_bounded_completion_live` reproduces #577: 5 concurrent jobs against a 2-context × 1-tab pool with slow fixture pages. Harness per-command timeout for `--wait` commands aligned with the CLI's built-in 300 s wait cap (the previous 120 s default killed valid runs whose jobs waited through the 30–44 s retry policy).

## Verification

- Rust unit tests: 1049 passed
- Kotlin tests (SwarmControllerTest, SwarmServicePersistenceTest, PulsarSessionManagerTest, XSQLScrapeHyperlinkTest, StreamingTaskRunnerRetryTest): 56 passed
- E2E: swarm group 11/11 passed including the live concurrency scenario against a locally built bundle

## Notes

- `cli/package-lock.json` version bumped to 4.13.9 and the stale self-dependency removed — drop if unintended.
- Retry bounding exists at two layers: this PR (runner, default 3) and #576 (MultiPrivacyContextManager, `fetch.maxPrivacyRetries`, default 5). The runner budget applies first; semantics are consistent (bounded, terminal failure), worth confirming before both merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `swarm close` support to the API and CLI.
  - Closing a swarm now aborts pending tasks and reports cleanup results.
  - CLI output includes clearer task statuses, failure messages, and response details.
  - Swarm processing can recover from unexpected runner exits and continue active work.

- **Bug Fixes**
  - Added bounded retry handling for canceled, failed, or unavailable pages.
  - Prevented stale or interrupted tasks from remaining indefinitely pending.
  - Improved failure reporting for terminal crawl errors.

- **Documentation**
  - Clarified `swarm close` behavior and CLI timeout defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->