### PR TITLE
docs(ci): note that fork PR gate runs require maintainer approval

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,13 @@ name: PR Quality Gate
 # PowerShell test scripts, and enforces a minimum JaCoCo coverage floor.
 # Heavy / Integration / E2E tests are intentionally excluded here (they run in
 # ci.yml on release tags and in nightly.yml) to keep PR validation quick.
+#
+# NOTE: For pull requests from FORKS, GitHub holds this workflow until a
+# maintainer approves it (first-time contributor protection for public repos).
+# Until approved, the run shows as "action_required" with zero jobs and no
+# logs — that is the expected waiting state, NOT a failure. Approve it from
+# the Actions tab ("Approve and run") or, for automation, with:
+#   POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve
 
 on:
   pull_request:


### PR DESCRIPTION
Documentation-only change: the PR Quality Gate is held in an `action_required`
state (zero jobs, no logs) for pull requests from forks until a maintainer
approves it — GitHub's first-time contributor protection for public repos.
This is expected behavior, not a workflow failure, and it has been confusing
(fork PRs #569 and #576 both appeared to have a silently broken gate).

Adds a note to the workflow header explaining how to approve: the Actions tab
"Approve and run" button, or `POST /repos/{owner}/{repo}/actions/runs/{run_id}/approve`
for automation. Verified: the approve endpoint starts the held run immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added explanatory notes about approval behavior for pull requests from forks.
  * Documented the expected approval-required state and approval API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->