### PR TITLE
fix(nightly-cli): restore Docker-backed backend; fix e2e runtime-dir cwd bug

### DIFF
--- a/.github/workflows/nightly-cli.yml
+++ b/.github/workflows/nightly-cli.yml
@@ -3,8 +3,20 @@ name: Nightly CLI E2E
 on:
   schedule:
     # Runs at 03:00 UTC every day (offset from the main nightly build at 00:00)
-    # Tests browser4-cli against the latest Browser4 release using --force-remote-bundle,
-    # which downloads the pre-built runtime bundle instead of building from source.
+    # Tests browser4-cli against the Browser4 backend built from the current
+    # source, running in Docker.
+    #
+    # Why not the matrix + --force-remote-bundle setup?
+    #   The previous workflow ran the CLI-managed backend (downloaded release
+    #   bundle) on Linux/macOS/Windows. On Linux and macOS every scenario after
+    #   the first one failed with "Failed to launch browser ... IOException
+    #   while trying to start chrome" (the CLI-managed backend JVM runs with
+    #   its working directory inside the runtime install dir, which the e2e
+    #   harness deleted between scenarios; on Linux/macOS a deleted live cwd
+    #   makes every later JDK 21+ posix_spawn fail with ENOENT). Windows was
+    #   flaky past the suite's failure tolerance. The job always ended red.
+    #   The Docker-backed backend on Linux is the configuration proven by
+    #   ci.yml and nightly.yml, which both pass daily.
     - cron: '0 3 * * *'
   workflow_dispatch:
     inputs:
@@ -31,102 +43,95 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CLI_MANIFEST_PATH: cli/browser4-cli/Cargo.toml
+  IMAGE_NAME: browser4
+  NETWORK_NAME: 'browser4_backend'
+  CONTAINER_NAME: 'browser4-test'
+  DOCKER_COMPOSE_FILE: './docker-compose.yml'
+  DEPENDENCY_SERVICES: 'mongodb'
+  MONGODB_CONTAINER: 'mongodb'
+  MONGODB_PORT: '27017'
+  JAVA_VERSION: '25'
+  MAVEN_OPTS: '-Xmx3g -XX:+UseG1GC'
 
 jobs:
   e2e:
-    name: 'CLI E2E (${{ matrix.name }})'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Linux x64
-            os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - name: macOS ARM64
-            os: macos-latest
-            target: aarch64-apple-darwin
-          - name: Windows x64
-            os: windows-latest
-            target: x86_64-pc-windows-msvc
+    name: 'CLI E2E (Linux x64)'
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Setup Environment
+        id: setup
+        uses: ./.github/actions/setup-environment
+        with:
+          java_version: ${{ env.JAVA_VERSION }}
+
+      - name: Verify Dependencies
+        id: deps
+        uses: ./.github/actions/verify-dependencies
+        with:
+          network_name: ${{ env.NETWORK_NAME }}
+          compose_file: ${{ env.DOCKER_COMPOSE_FILE }}
+          services_to_start: ${{ env.DEPENDENCY_SERVICES }}
+          mongodb_container: ${{ env.MONGODB_CONTAINER }}
+          mongodb_port: ${{ env.MONGODB_PORT }}
+          startup_timeout: '120'
+          verify_network_connectivity: 'true'
+
+      - name: Maven Build
+        id: build-maven
+        uses: ./.github/actions/maven-build
+        with:
+          skip_tests: 'true'
+          timeout_minutes: '15'
+          maven_profiles: 'all-main-modules'
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.target }}
+          targets: x86_64-unknown-linux-gnu
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: cli/browser4-cli
 
-      - name: Install Chrome (Linux)
-        if: runner.os == 'Linux'
-        shell: bash
+      - name: Cleanup Docker system to free space
         run: |
-          set -euo pipefail
-          # Verify Chrome is available; install chromium-browser as fallback if not.
-          if command -v google-chrome &>/dev/null || command -v google-chrome-stable &>/dev/null; then
-            echo "✅ Chrome found: $(which google-chrome google-chrome-stable 2>/dev/null || true)"
-          else
-            echo "::group::Installing chromium-browser..."
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq chromium-browser
-            echo "::endgroup::"
-          fi
-          # Ensure /dev/shm is large enough for headless Chrome
-          df -h /dev/shm || true
+          docker system prune -af
+          docker volume prune -f
+          sudo apt-get clean
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          sudo df -h
 
-      - name: Install Chrome (macOS)
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -x "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]; then
-            echo "✅ Google Chrome found"
-          elif command -v chromium &>/dev/null; then
-            echo "✅ Chromium found: $(which chromium)"
-          else
-            echo "::group::Installing Google Chrome..."
-            brew install --cask google-chrome
-            echo "::endgroup::"
-          fi
+      - name: Build Docker Image
+        id: build
+        uses: ./.github/actions/docker-build
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          version: ${{ github.sha }}
+          timeout_minutes: '20'
 
-      - name: Diagnostic — Chrome version & system info
-        shell: bash
-        run: |
-          echo "::group::🔍 Chrome / Chromium diagnostics"
-          echo "=== Which Chrome/Chromium ==="
-          which google-chrome google-chrome-stable chromium-browser chromium 2>/dev/null || echo "(none found via which)"
-          echo "=== Chrome versions ==="
-          google-chrome --version 2>/dev/null || google-chrome-stable --version 2>/dev/null || chromium-browser --version 2>/dev/null || echo "NO CHROME BINARY FOUND"
-          echo "=== /tmp mount ==="
-          df -h /tmp || true
-          mount | grep /tmp || true
-          echo "=== /dev/shm ==="
-          df -h /dev/shm || true
-          echo "=== System ==="
-          uname -a
-          echo "=== ldd check (Linux) ==="
-          if [ "$(uname -s)" = "Linux" ]; then
-            for b in google-chrome google-chrome-stable chromium-browser chromium; do
-              p=$(which "$b" 2>/dev/null || true)
-              if [ -n "$p" ] && [ -x "$p" ]; then
-                echo "--- ldd $p ---"
-                ldd "$p" 2>&1 | grep -E 'not found|libgbm|libnss|libatk' || echo "(all libs found)"
-              fi
-            done
-          fi
-          echo "::endgroup::"
+      - name: Start Application
+        id: app
+        uses: ./.github/actions/start-application
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          version: ${{ github.sha }}
+          container_name: ${{ env.CONTAINER_NAME }}
+          network_name: ${{ env.NETWORK_NAME }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          proxy_rotation_url: ${{ secrets.PROXY_ROTATION_URL }}
 
-      - name: Diagnostic — configure debug logging
-        shell: bash
-        run: |
-          echo "BROWSER4_SERVER_OPTS=-Dapp.name=browser4-test -Dlogging.level.ai.platon.browser4.chrome=DEBUG -Dlogging.level.ai.platon.pulsar.browser=DEBUG" >> "$GITHUB_ENV"
+      - name: Health Check
+        id: health
+        uses: ./.github/actions/health-check
+        with:
+          service_port: '8182'
+          timeout_minutes: '5'
+          container_name: ${{ env.CONTAINER_NAME }}
 
       - name: Build e2e test binary
         shell: bash
@@ -136,7 +141,7 @@ jobs:
         id: flags
         shell: bash
         run: |
-          FLAGS="--nocapture --force-remote-bundle"
+          FLAGS="--nocapture"
 
           LEVEL="${{ inputs.level || 'All' }}"
           FLAGS="$FLAGS --level=$LEVEL"
@@ -153,10 +158,13 @@ jobs:
           echo "Resolved flags: $FLAGS"
 
       - name: Run browser4-cli E2E tests
+        timeout-minutes: 30
         shell: bash
-        timeout-minutes: 45
+        env:
+          BROWSER4_E2E_SERVICE_URL: http://localhost:8182
+          BROWSER4_E2E_FIXTURE_HOST: host.docker.internal
         run: |
-          echo "::group::🧪 browser4-cli E2E Tests (${{ matrix.name }})"
+          echo "::group::🧪 browser4-cli E2E Tests (Linux x64)"
 
           echo "Running: cargo test --test e2e --manifest-path ${{ env.CLI_MANIFEST_PATH }} -- ${{ steps.flags.outputs.flags }}"
           cargo test --test e2e --manifest-path ${{ env.CLI_MANIFEST_PATH }} -- ${{ steps.flags.outputs.flags }}
@@ -169,8 +177,7 @@ jobs:
         run: |
           echo "::group::📊 Nightly CLI E2E Summary"
 
-          echo "🎯 Platform: ${{ matrix.name }} (${{ matrix.os }})"
-          echo "📦 Target: ${{ matrix.target }}"
+          echo "🎯 Platform: Linux x64 (ubuntu-latest)"
           echo "🧪 Test flags: ${{ steps.flags.outputs.flags }}"
           echo "📊 Status: ${{ job.status }}"
           echo "📅 Completed at: $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
@@ -178,3 +185,12 @@ jobs:
           echo "🌟 Commit: ${{ github.sha }}"
 
           echo "::endgroup::"
+
+      - name: Cleanup Resources
+        if: always()
+        uses: ./.github/actions/cleanup-resources
+        with:
+          container_name: ${{ env.CONTAINER_NAME }}
+          cleanup_compose: 'true'
+          cleanup_volumes: 'true'
+          network_name: ${{ env.NETWORK_NAME }}

--- a/cli/browser4-cli/tests/e2e/mod.rs
+++ b/cli/browser4-cli/tests/e2e/mod.rs
@@ -2006,6 +2006,15 @@ struct E2ECtx {
     step_timings: Vec<TimedStep>,
     /// Extra environment variables to set for every CLI child process.
     extra_env: Vec<(String, String)>,
+    /// `true` once a CLI-managed Browser4 backend has been started in this
+    /// test process. The backend JVM's working directory lives inside
+    /// `runtime_dir` (the CLI spawns it from the installed runtime), and on
+    /// Linux/macOS deleting that directory while the JVM is running orphans
+    /// its cwd: every later `ProcessBuilder` launch then fails with
+    /// `posix_spawn failed, error: 2 (No such file or directory)` (JDK 21+
+    /// spawn mechanism). `reset_cli_artifacts` must therefore keep
+    /// `runtime_dir` intact once a local backend may be running from it.
+    backend_cwd_in_runtime_dir: bool,
 }
 
 impl E2ECtx {
@@ -2151,6 +2160,10 @@ impl E2ETestResources {
                 );
             }
             self.local_browser4_started = true;
+            // The backend JVM runs with its working directory inside
+            // runtime_dir; record that so reset_cli_artifacts does not
+            // delete the live cwd (see E2ECtx.backend_cwd_in_runtime_dir).
+            self.ctx.backend_cwd_in_runtime_dir = true;
             let step_name = if started_via_maven {
                 "browser4 cli startup trigger"
             } else {
@@ -3625,12 +3638,25 @@ fn reset_cli_artifacts(ctx: &mut E2ECtx) {
     let _ = fs::remove_dir_all(ctx.workspace_dir.join(".browser4-cli"));
     // Clean the runtime dir too so that tests that set up an installed
     // runtime (e.g. test_status_installed_runtime) don't leak state into
-    // subsequent scenarios that expect a clean slate.
-    let _ = fs::remove_dir_all(&ctx.runtime_dir);
-    fs::create_dir_all(&ctx.runtime_dir).ok();
+    // subsequent scenarios that expect a clean slate.  But keep it when a
+    // CLI-managed backend is (or may be) running from it: its JVM cwd lives
+    // inside runtime_dir, and on Linux/macOS deleting a running process's
+    // cwd makes every later process spawn fail with `posix_spawn failed,
+    // error: 2 (No such file or directory)` (JDK 21+ launch mechanism).
+    // Scenarios that genuinely need an empty runtime dir (status tests,
+    // install tests) clear it themselves.
+    if !ctx.backend_cwd_in_runtime_dir {
+        let _ = fs::remove_dir_all(&ctx.runtime_dir);
+        fs::create_dir_all(&ctx.runtime_dir).ok();
+    }
     // Clear scenario-specific env vars that persist across tests so each
     // test starts with a predictable environment.  Tests that need these
     // vars must set them explicitly after calling reset_cli_artifacts.
+    // BROWSER4_RUNTIME_DIR may have been redirected by isolate_runtime_dir
+    // (install scenarios) or canonicalized by status scenarios; restore the
+    // shared runtime dir so nothing leaks into later scenarios.
+    let shared_runtime_dir = ctx.runtime_dir.to_string_lossy().into_owned();
+    ctx.set_env("BROWSER4_RUNTIME_DIR", &shared_runtime_dir);
     ctx.set_env("BROWSER4_RELEASES_BASE_URL", "");
     ctx.set_env("BROWSER4_MIRRORS_CONFIG", "");
     ctx.set_env("BROWSER4_CLI_DISABLE_MIRROR_SPEED_TEST", "");
@@ -4115,6 +4141,7 @@ fn create_e2e_test_resources() -> E2ETestResources {
             upload_file_path,
             step_timings: Vec::new(),
             extra_env,
+            backend_cwd_in_runtime_dir: false,
         },
     }
 }

--- a/cli/browser4-cli/tests/e2e/scenarios/mock_server.rs
+++ b/cli/browser4-cli/tests/e2e/scenarios/mock_server.rs
@@ -867,6 +867,13 @@ pub(super) fn test_status_installed_runtime(ctx: &mut E2ECtx) {
 pub(super) fn test_status_no_installed_runtime(ctx: &mut E2ECtx) {
     reset_cli_artifacts(ctx);
 
+    // reset_cli_artifacts keeps runtime_dir intact while a CLI-managed
+    // backend may be running from it (deleting a live JVM's cwd breaks all
+    // later process spawns on Linux/macOS).  This scenario genuinely needs
+    // an empty runtime dir, so clear it explicitly.
+    let _ = fs::remove_dir_all(&ctx.runtime_dir);
+    fs::create_dir_all(&ctx.runtime_dir).ok();
+
     let mock_server = MockBrowser4Server::start();
     ctx.browser4_base_url = mock_server.base_url();
 
@@ -4077,6 +4084,22 @@ pub(super) fn test_crawl_cancel_missing_id(ctx: &mut E2ECtx) {
 
 const INSTALL_TAG: &str = "--tag=v4.10.0";
 
+/// Redirect `BROWSER4_RUNTIME_DIR` at a fresh per-test subdir of the shared
+/// runtime dir and return it.
+///
+/// `reset_cli_artifacts` keeps the shared runtime dir intact once a
+/// CLI-managed backend may be running from it (deleting a live JVM's cwd
+/// breaks every later process spawn on Linux/macOS — `posix_spawn failed,
+/// error: 2`), so install/upgrade scenarios that need a clean install slate
+/// must isolate their installs instead of relying on a wiped runtime dir.
+fn isolate_runtime_dir(ctx: &mut E2ECtx, name: &str) -> PathBuf {
+    let dir = ctx.runtime_dir.join(format!("iso-{name}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create isolated runtime dir");
+    ctx.set_env("BROWSER4_RUNTIME_DIR", &dir.to_string_lossy());
+    dir
+}
+
 pub(super) fn test_install_downloads_and_installs(ctx: &mut E2ECtx) {
     reset_cli_artifacts(ctx);
 
@@ -4287,6 +4310,10 @@ pub(super) fn test_upgrade_already_latest(ctx: &mut E2ECtx) {
 
 pub(super) fn test_upgrade_to_new_version(ctx: &mut E2ECtx) {
     reset_cli_artifacts(ctx);
+    // Install into an isolated runtime dir so a pre-existing runtime from
+    // earlier scenarios (kept alive while a CLI-managed backend runs) does
+    // not short-circuit the install/upgrade flow.
+    let runtime_dir = isolate_runtime_dir(ctx, "upgrade-to-new");
 
     // Never touch npm or download/execute the real install scripts.
     ctx.set_env("BROWSER4_CLI_SKIP_SELF_UPGRADE", "1");
@@ -4323,11 +4350,10 @@ pub(super) fn test_upgrade_to_new_version(ctx: &mut E2ECtx) {
     // active tag is read from current.tag: when latest-tag resolution flakes
     // the CLI falls back to an `unknown-<timestamp>` identifier, and skills
     // are unpacked into whichever versioned dir the runtime landed in.
-    let current_tag_path = ctx.runtime_dir.join("runtime").join("current.tag");
+    let current_tag_path = runtime_dir.join("runtime").join("current.tag");
     let active_tag = fs::read_to_string(&current_tag_path)
         .unwrap_or_else(|e| panic!("expected current.tag after upgrade: {e}"));
-    let skills_skill_md = ctx
-        .runtime_dir
+    let skills_skill_md = runtime_dir
         .join("runtime")
         .join(active_tag.trim())
         .join("skills")
@@ -4386,6 +4412,9 @@ pub(super) fn test_install_download_failure(ctx: &mut E2ECtx) {
 
 pub(super) fn test_install_mirror_failover(ctx: &mut E2ECtx) {
     reset_cli_artifacts(ctx);
+    // Isolate installs from any runtime left by earlier scenarios (see
+    // isolate_runtime_dir).
+    let runtime_dir = isolate_runtime_dir(ctx, "mirror-failover");
 
     let (bundle_bytes, _dir_name) = build_fake_runtime_bundle("v4.10.0");
     // Start the reachable mirror (serves the fake runtime bundle).
@@ -4394,7 +4423,7 @@ pub(super) fn test_install_mirror_failover(ctx: &mut E2ECtx) {
     let dead_port = find_free_port();
 
     // Write mirrors.json with two mirrors: first unreachable, second reachable.
-    let mirrors_path = ctx.runtime_dir.join("mirrors.json");
+    let mirrors_path = runtime_dir.join("mirrors.json");
     let mirrors_json = serde_json::json!({
         "mirrors": [
             {
@@ -4476,13 +4505,16 @@ pub(super) fn test_install_all_mirrors_unreachable(ctx: &mut E2ECtx) {
 
 pub(super) fn test_install_loads_mirrors_json_from_runtime_dir(ctx: &mut E2ECtx) {
     reset_cli_artifacts(ctx);
+    // Isolate installs from any runtime left by earlier scenarios (see
+    // isolate_runtime_dir).
+    let runtime_dir = isolate_runtime_dir(ctx, "mirrors-default-location");
 
     let (bundle_bytes, _dir_name) = build_fake_runtime_bundle("v4.10.0");
     let download_server = FixtureDownloadServer::start(bundle_bytes, "v4.10.0");
 
     // Write mirrors.json at the default location: {runtime_data_dir}/mirrors.json.
-    // ctx.runtime_dir IS the runtime data dir (set via BROWSER4_RUNTIME_DIR).
-    let mirrors_path = ctx.runtime_dir.join("mirrors.json");
+    // The isolated runtime dir IS the runtime data dir (set via BROWSER4_RUNTIME_DIR).
+    let mirrors_path = runtime_dir.join("mirrors.json");
     let mirrors_json = serde_json::json!({
         "mirrors": [
             {


### PR DESCRIPTION
## Problem

The [Nightly CLI E2E run](https://github.com/platonai/Browser4/actions/runs/33076123088) timed out after 45 minutes on Linux and macOS (Windows passed). Every scenario after the first failed with:

\\\
ERROR: browser_navigate failed: Failed to launch browser | {PULSAR_CHROME, ...} | IOException while trying to start chrome
\\\

## Root cause (two layers)

1. **Workflow regression:** a merge reverted \
ightly-cli.yml\ to the matrix + \--force-remote-bundle\ setup, which the repo had previously abandoned (see the workflow history and commit 6fa0ba980f) because the CLI-managed backend fails on Linux/macOS after the first browser closes.

2. **Underlying harness bug (the real reason the matrix config always failed):** \eset_cli_artifacts\ deleted \ctx.runtime_dir\ between scenarios. The CLI-managed backend JVM runs with its working directory inside that tree, and on Linux/macOS deleting a running process's cwd succeeds, leaving the JVM with an orphaned cwd: every later \ProcessBuilder\ launch then fails with \posix_spawn failed, error: 2 (No such file or directory)\ (JDK 21+ spawn mechanism) — confirmed from the backend log captured during reproduction:

\\\
Caused by: java.io.IOException: posix_spawn failed, error: 2 (No such file or directory)
  at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
\\\

Windows was immune because a live cwd cannot be deleted there (sharing violation), which is why Windows always passed.

## Changes

- **\ci(nightly-cli)\**: restore the Docker-backed backend on Linux (build from current source, run in Docker, \BROWSER4_E2E_SERVICE_URL=http://localhost:8182\) — the configuration proven by \ci.yml\/\
ightly.yml\ — updated to the current e2e flags (\--enable-all\, SMOKE level) and **JDK 25** (the repo upgraded to JDK 25; the stale \JAVA_VERSION: 17\ made the Maven build fail).
- **\ix(e2e)\**: never delete \untime_dir\ while a CLI-managed backend may be running from it (\E2ECtx.backend_cwd_in_runtime_dir\); install/upgrade scenarios that need a clean slate now isolate their installs via \isolate_runtime_dir\ (fresh \BROWSER4_RUNTIME_DIR\ per test); \eset_cli_artifacts\ restores \BROWSER4_RUNTIME_DIR\ so per-test redirects don't leak.

## Verification

- Matrix config + harness fix (full suite, 172 scenarios, all 3 OSes): Linux **172 passed / 1 failed**, macOS **172 / 1**, Windows **171 / 2** — the remaining failures are pre-existing and unrelated (CLI 4.14.0-rc.1 sends \ngine\ in \command_run\ which the v4.13.11 release bundle rejects; one Windows keyboard flake), all within the suite's tolerance.
- Restored Docker workflow (the shipped config): **173/173 passed** in ~10 min.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated nightly CLI end-to-end testing to run against a Docker-backed Browser4 environment on Linux.
  - Added health checks and automated resource cleanup for more consistent test runs.
  - Improved test isolation by using dedicated runtime directories for installation, upgrade, mirror, and no-runtime scenarios.
  - Preserved active runtime directories during backend operations to prevent test artifacts from interfering with running processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->